### PR TITLE
Improved type error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An in-memory incremental Datalog engine based on Differential Dataflow.
 This is currently very early work-in-progress.
 
 Language reference for the Datalog dialect implemented by the tool
-can be found at [here](doc/language_reference/language_reference.md).
+can be found [here](doc/language_reference/language_reference.md).
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An in-memory incremental Datalog engine based on Differential Dataflow.
 This is currently very early work-in-progress.
 
 Language reference for the Datalog dialect implemented by the tool
-can be found at [here](blob/master/doc/language_reference/language_reference.md).
+can be found at [here](doc/language_reference/language_reference.md).
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 An in-memory incremental Datalog engine based on Differential Dataflow.
 This is currently very early work-in-progress.
 
+Language reference for the Datalog dialect implemented by the tool
+can be found at [here](blob/master/doc/language_reference/language_reference.md).
+
 # Requirements
 
 We have only tested our software on Ubuntu Linux.

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -85,6 +85,7 @@ module Language.DifferentialDatalog.Syntax (
         ePHolder,
         eTyped,
         Function(..),
+        funcShowProto,
         funcTypeVars,
         DatalogProgram(..),
         emptyDatalogProgram,
@@ -614,7 +615,7 @@ instance WithName Function where
 
 instance PP Function where
     pp Function{..} = ("function" <+> pp funcName
-                       <+> (parens $ hcat $ punctuate comma $ map pp funcArgs)
+                       <+> (parens $ hsep $ punctuate comma $ map pp funcArgs)
                        <> colon <+> pp funcType
                        <+> (maybe empty (\_ -> "=") funcDef))
                       $$
@@ -622,6 +623,12 @@ instance PP Function where
 
 instance Show Function where
     show = render . pp
+
+funcShowProto :: Function -> String
+funcShowProto Function{..} = render $
+    "function" <+> pp funcName
+    <+> (parens $ hsep $ punctuate comma $ map pp funcArgs)
+    <> colon <+> pp funcType
 
 -- | Type variables used in function declaration
 funcTypeVars :: Function -> [String]

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -110,7 +110,7 @@ unifyTypes d p ctx ts = do
 checkConflicts :: (MonadError String me) => DatalogProgram -> Pos -> String -> String -> [Type] -> me Type
 checkConflicts d p ctx v (t:ts) = do
     mapM (\t' -> when (not $ typesMatch d t t') 
-                      $ err p $ "Conflicting types " ++ show t ++ " and " ++ show t' ++ " for type variable '" ++ v ++ " " ++ ctx) ts
+                      $ err p $ "Conflicting bindings " ++ show t ++ " and " ++ show t' ++ " for type variable '" ++ v ++ " " ++ ctx) ts
     return t
 
 unifyTypes' :: (MonadError String me) => DatalogProgram -> Pos -> String -> (Type, Type) -> me (M.Map String Type)
@@ -131,11 +131,6 @@ unifyTypes' d p ctx (a, c) =
         _                                    -> err p $ "Cannot match expected type " ++ show a ++ " and actual type " ++ show c ++ " " ++ ctx  
     where a' = typ'' d a
           c' = typ'' d c
-
--- | Visitor pattern implementation that carries type information
--- through the syntax tree.
---exprTraverseTypeM :: (Monad m) => DatalogProgram -> (ECtx -> ExprNode (Maybe Type) -> m ()) -> ECtx -> Expr -> m ()
---exprTraverseTypeM d = exprTraverseCtxWithM (\ctx e -> return $ exprNodeType d ctx e)
 
 -- | Compute type of an expression.  The expression must be previously validated
 -- to make sure that it has an unambiguous type.

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -168,7 +168,7 @@ exprNodeType d ctx e = fmap ((flip atPos) (pos e)) $ exprNodeType' d ctx (exprMa
 
 funcTypeArgSubsts :: (MonadError String me) => DatalogProgram -> Pos -> Function -> [Type] -> me (M.Map String Type)
 funcTypeArgSubsts d p f@Function{..} argtypes = 
-    unifyTypes d p ("in call to function " ++ funcShowProto f) (zip (map typ funcArgs) argtypes)
+    unifyTypes d p ("in call to " ++ funcShowProto f) (zip (map typ funcArgs) argtypes)
 
 structTypeArgs :: (MonadError String me) => DatalogProgram -> Pos -> ECtx -> String -> [(String, Type)] -> me [Type]
 structTypeArgs d p ctx cname argtypes = do

--- a/src/Language/DifferentialDatalog/Type.hs-boot
+++ b/src/Language/DifferentialDatalog/Type.hs-boot
@@ -11,5 +11,3 @@ instance WithType Field where
 ctxExpectType :: DatalogProgram -> ECtx -> Maybe Type
 exprType :: DatalogProgram -> ECtx -> Expr -> Type
 exprType' :: DatalogProgram -> ECtx -> Expr -> Type
-exprTypeMaybe :: DatalogProgram -> ECtx -> Expr -> Maybe Type
-

--- a/test/datalog_tests/function.ast.expected
+++ b/test/datalog_tests/function.ast.expected
@@ -15,11 +15,11 @@ function a3 (): bit<32> =
     (0: bit<32>)
 function a4 (): bit<32> =
     (0: bit<64>)[40:9]
-function a5 (a: bit<32>,b: bit<32>): bit<32> =
+function a5 (a: bit<32>, b: bit<32>): bit<32> =
     ((((((a & b) | (a | b)) | (~ a)) | (a << 32'd5)) | (a >> 32'd5)) | (a[15:0] ++ a[31:16]))
-function a6 (a: bit<16>,b: bit<16>): bit<16> =
+function a6 (a: bit<16>, b: bit<16>): bit<16> =
     (((((a + b) + (a - b)) + (a / b)) + (a * b)) + (a % b))
-function a7 (a: bit<16>,b: bit<16>): bool =
+function a7 (a: bit<16>, b: bit<16>): bool =
     (((((((a < b) or (a > b)) or (a <= b)) or (a >= b)) or (a == b)) or (a != b)) or (a < b))
 function a8 (): bit<32> =
     (((32'd125 | 32'd255) | 32'd511) | 32'd683)
@@ -27,7 +27,7 @@ function b0 (): bool =
     (true and false)
 function b1 (a: bool): bool =
     ((((a and true) or (a or false)) or (a => false)) or (not a))
-function c0 (a: bit<32>,b: bit<16>): bit<16> =
+function c0 (a: bit<32>, b: bit<16>): bit<16> =
     (a;
      b)
 function f (): int
@@ -36,7 +36,7 @@ function fnested (x: nested_t): string =
      res)
 function g (a: int): int
 function h (a: (int, int)): (int, int)
-function parameterized (x: 'A,y: 'A): 'A
+function parameterized (x: 'A, y: 'A): 'A
 function patterns (): () =
     ((var a: Alt) = C0{.x=1};
      (var b = match (a) {
@@ -58,7 +58,7 @@ function shadow (): string =
           Some{.value=var v} -> v,
           None{} -> ""
       }))
-function use_parameterized (x: string,y: string_syn): string =
+function use_parameterized (x: string, y: string_syn): string =
     parameterized(x, y)
 function v (): string =
     ((var v1: string) = "hello";

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -16,5 +16,6 @@ error: ./test/datalog_tests/function.fail.dl:9:5-9:17: Type constructor in the l
 
 error: ./test/datalog_tests/function.fail.dl:11:16-11:27: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "option_t" has multiple constructors
 
-error: ./test/datalog_tests/function.fail.dl:6:5-7:1: Expression parameterized(string, int) has unknown type in CtxTop
-CtxFunc            use_parameterized
+error: ./test/datalog_tests/function.fail.dl:6:5-8:1: Conflicting types string and int for type variable 'A in call to function function parameterized (x: 'A, y: 'A): 'A
+
+error: ./test/datalog_tests/function.fail.dl:4:5-4:6: Expression is not a struct

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -16,6 +16,6 @@ error: ./test/datalog_tests/function.fail.dl:9:5-9:17: Type constructor in the l
 
 error: ./test/datalog_tests/function.fail.dl:11:16-11:27: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "option_t" has multiple constructors
 
-error: ./test/datalog_tests/function.fail.dl:6:5-8:1: Conflicting types string and int for type variable 'A in call to function function parameterized (x: 'A, y: 'A): 'A
+error: ./test/datalog_tests/function.fail.dl:6:5-8:1: Conflicting types string and int for type variable 'A in call to function parameterized (x: 'A, y: 'A): 'A
 
 error: ./test/datalog_tests/function.fail.dl:4:5-4:6: Expression is not a struct

--- a/test/datalog_tests/function.fail.dl
+++ b/test/datalog_tests/function.fail.dl
@@ -104,3 +104,8 @@ function parameterized(x: 'A, y: 'A): 'A
 
 function use_parameterized(x: string, y: int): string = 
     parameterized(x,y) // error: x and y must have the same type
+
+//---
+
+function foo(x: int): string = 
+    x.bar // x is not a struct

--- a/test/datalog_tests/pattern.ast.expected
+++ b/test/datalog_tests/pattern.ast.expected
@@ -3,7 +3,7 @@ typedef T2 = C21{f1: T1, f2: int} | C22{f3: (bool, T1)}
 typedef T3 = C31{f1: T1, f2: int, s: string, b: bit<32>} | C32{f3: ((bool, (bool, bool, bool)), T1)}
 typedef set<'A>
 function __builtin_2string (x: 'X): string
-function f1 (x: T1,y: T2,q: T3): bool =
+function f1 (x: T1, y: T2, q: T3): bool =
     (match (x) {
          C11{.f1=_, .f2=_} -> true,
          _ -> false

--- a/test/datalog_tests/strings.fail.ast.expected
+++ b/test/datalog_tests/strings.fail.ast.expected
@@ -8,4 +8,4 @@ error: ./test/datalog_tests/strings.fail.dl:7:18-7:19: Cannot find declaration o
 
 error: ./test/datalog_tests/strings.fail.dl:6:24-6:28: Unknown variable: str1
 
-error: ./test/datalog_tests/strings.fail.dl:9:1-13:1: string conversion function "serializable_t2string" must take argument of type serializable_t
+error: ./test/datalog_tests/strings.fail.dl:19:17-19:50: Cannot match expected type int and actual type serializable_t in the call to string conversion function "serializable_t2string"


### PR DESCRIPTION
propagate the reason why expression type cannot be determined to the compiler error message.

Old error message:
```
error: ./test/datalog_tests/function.fail.dl:6:5-7:1: Expression parameterized(string, int) has unknown type in CtxTop
```

New error message
```
error: ./test/datalog_tests/function.fail.dl:6:5-8:1: Conflicting types string and int for type variable 'A in call to function parameterized (x: 'A, y: 'A): 'A
```