### PR TITLE
Record types

### DIFF
--- a/doc/language_reference/language_reference.md
+++ b/doc/language_reference/language_reference.md
@@ -180,6 +180,20 @@ arg ::= arg_name ":" simple_type_spec
 
 ```EBNF
 relation ::= ["ground"] "relation" rel_name "(" [arg ","] arg ")"
+           | ["ground"] "relation" rel_name "[" simple_type_spec "]"
+```
+
+The first form declares relation by listing its arguments.  The second 
+form explicitly specifies relation's element type.  The
+second form is more general:
+
+```
+relation R(f1: int, f2: bool)
+```
+is equivalent to:
+```
+typedef R = R{f1: int, f2:bool}
+relation R[R]
 ```
 
 ### Constraints of relations
@@ -197,8 +211,8 @@ expr ::= term
        | "not" expr                      (*boolean negation*)
        | "(" expr ")"                    (*grouping*)
        | "{" expr "}"                    (*grouping (alternative syntax)*)
-       | expr "*" expr                   (* multiplication *)
-       | expr "/" expr                   (* division *)
+       | expr "*" expr                   (*multiplication*)
+       | expr "/" expr                   (*division*)
        | expr "%" expr                   (*remainder*)
        | expr "+" expr
        | expr "-" expr
@@ -457,6 +471,7 @@ rule ::= atom (,atom)* ":-" rhs_clause (,rhs_clause)*
 
 atom ::= rel_name "(" expr (,expr)* ")"
        | rel_name "(" "." arg_name "=" expr [("," "." arg_name "=" expr)*] ")"
+       | rel_name "[" expr "]"
 
 rhs_clause ::= atom                                      (* 1.atom *)
              | "not" atom                                (* 2.negated atom *)
@@ -468,7 +483,18 @@ rhs_clause ::= atom                                      (* 1.atom *)
                 var_name "=" expr ")"
 ```
 
-An atom is a predicate that holds when a given tuple belongs to a relation.
+An atom is a predicate that holds when a given value belongs to a relation.
+It can be specified by listing its fields or by giving its value explicitly.  
+The former is a special case of the latter:
+
+```
+Rel(val1, val2)
+```
+is expanded into
+```
+Rel[Rel1(val1, val2)]
+```
+
 A body clause can have several forms.  The
 first two forms (`atom` and `"not" atom`) represent a *literal*, i.e.,
 an atom or its negation:

--- a/src/Language/DifferentialDatalog/DatalogProgram.hs
+++ b/src/Language/DifferentialDatalog/DatalogProgram.hs
@@ -51,10 +51,10 @@ progExprMapCtxM d fun = do
     return d{ progFunctions = funcs'
             , progRules     = rules'}    
 
-atomExprMapCtxM :: (Monad m) => DatalogProgram -> (ECtx -> ENode -> m Expr) -> (String -> ECtx) -> Atom -> m Atom
-atomExprMapCtxM d fun fctx a = do 
-    args <- mapM (\(m, e) -> (m,) <$> exprFoldCtxM fun (fctx m) e) $ atomArgs a
-    return a{atomArgs = args}
+atomExprMapCtxM :: (Monad m) => DatalogProgram -> (ECtx -> ENode -> m Expr) -> ECtx -> Atom -> m Atom
+atomExprMapCtxM d fun ctx a = do
+    v <- exprFoldCtxM fun ctx $ atomVal a
+    return a{atomVal = v}
 
 rhsExprMapCtxM :: (Monad m) => DatalogProgram -> (ECtx -> ENode -> m Expr) -> Rule -> Int -> RuleRHS -> m RuleRHS
 rhsExprMapCtxM d fun r rhsidx l@RHSLiteral{}   = do

--- a/src/Language/DifferentialDatalog/ECtx.hs
+++ b/src/Language/DifferentialDatalog/ECtx.hs
@@ -39,8 +39,7 @@ module Language.DifferentialDatalog.ECtx(
      ctxInSeq1,
      ctxIsTyped,
      ctxIsRuleRCond,
-     ctxInRuleRHSPattern,
-     ctxIsRuleRHSPattern)
+     ctxInRuleRHSPattern)
 where
 
 import Data.Maybe
@@ -97,10 +96,8 @@ ctxIsRuleRCond _              = False
 -- rule, in a pattern expression, i.e., an expression where new
 -- variables can be declared.
 ctxInRuleRHSPattern :: ECtx -> Bool
-ctxInRuleRHSPattern ctx = any ctxIsRuleRHSPattern $ ctxAncestors ctx
-
-ctxIsRuleRHSPattern :: ECtx -> Bool
-ctxIsRuleRHSPattern (CtxRuleRAtom rl idx f) = pol && exprIsPattern arg
-    where RHSLiteral pol Atom{..} = ruleRHS rl !! idx
-          arg = fromJust $ lookup f atomArgs
-ctxIsRuleRHSPattern _ = False
+ctxInRuleRHSPattern (CtxRuleRAtom rl idx) = rhsPolarity $ ruleRHS rl !! idx
+ctxInRuleRHSPattern CtxStruct{..}         = ctxInRuleRHSPattern ctxPar
+ctxInRuleRHSPattern CtxTuple{..}          = ctxInRuleRHSPattern ctxPar
+ctxInRuleRHSPattern CtxTyped{..}          = ctxInRuleRHSPattern ctxPar
+ctxInRuleRHSPattern _                     = False

--- a/src/Language/DifferentialDatalog/NS.hs
+++ b/src/Language/DifferentialDatalog/NS.hs
@@ -125,8 +125,8 @@ ctxMVars d ctx =
     case ctx of
          CtxTop                   -> ([], [])
          CtxFunc f                -> ([], map f2mf $ funcArgs f)
-         CtxRuleL rl _ _          -> ([], map f2mf $ ruleVars d rl)
-         CtxRuleRAtom rl i _      -> ([], map f2mf $ ruleRHSVars d rl i)
+         CtxRuleL rl _            -> ([], map f2mf $ ruleVars d rl)
+         CtxRuleRAtom rl i        -> ([], map f2mf $ ruleRHSVars d rl i)
          CtxRuleRCond rl i        -> ([], map f2mf $ ruleRHSVars d rl i)
          CtxRuleRFlatMap rl i     -> ([], map f2mf $ ruleRHSVars d rl i)
          CtxRuleRAggregate rl i   -> ([], map f2mf $ ruleRHSVars d rl i)

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -152,25 +152,40 @@ removeTabs = do s <- getInput
                 setInput s'
 
 withPos x = (\ s a e -> atPos a (s,e)) <$> getPosition <*> x <*> getPosition
+withPosMany x = (\ s as e -> map (\a -> atPos a (s,e)) as) <$> getPosition <*> x <*> getPosition
 
-data SpecItem = SpType         TypeDef
-              | SpRelation     Relation
-              | SpRule         Rule
-              | SpFunc         Function
-              | SpStatement    Statement
+data SpecItem = SpType      TypeDef
+              | SpRelation  Relation
+              | SpRule      Rule
+              | SpFunc      Function
+              | SpStatement Statement
+
+instance WithPos SpecItem where
+    pos   (SpType         t)   = pos t
+    pos   (SpRelation     r)   = pos r
+    pos   (SpRule         r)   = pos r
+    pos   (SpFunc         f)   = pos f
+    pos   (SpStatement    s)   = pos s
+    atPos (SpType         t) p = SpType      $ atPos t p
+    atPos (SpRelation     r) p = SpRelation  $ atPos r p
+    atPos (SpRule         r) p = SpRule      $ atPos r p
+    atPos (SpFunc         f) p = SpFunc      $ atPos f p
+    atPos (SpStatement    s) p = SpStatement $ atPos s p
+   
 
 datalogGrammar preamble = removeTabs *> ((optional whiteSpace) *> spec preamble <* eof)
 exprGrammar = removeTabs *> ((optional whiteSpace) *> expr <* eof)
 
 spec preamble = do
-    items <- many decl
+    items <- concat <$> many decl
+
     let relations = (M.toList $ progRelations preamble) ++
                     mapMaybe (\i -> case i of
                                          SpRelation r -> Just (name r, r)
                                          _            -> Nothing) items
     let types = (M.toList $ progTypedefs preamble) ++
                 mapMaybe (\i -> case i of
-                                     SpType t -> Just (name t, t)
+                                     SpType t         -> Just (name t, t)
                                      _        -> Nothing) items
     let funcs = (M.toList $ progFunctions preamble) ++
                 mapMaybe (\i -> case i of
@@ -194,34 +209,48 @@ spec preamble = do
          Left err   -> error err
          Right prog -> return prog
 
-decl =  (SpType         <$> typeDef)
-    <|> (SpRelation     <$> relation)
-    <|> (SpFunc         <$> func)
-    <|> (SpRule         <$> rule)
-    <|> (SpStatement    <$> parseForStatement)
+decl = withPosMany $
+        (return . SpType)      <$> typeDef
+    <|> relation
+    <|> (return . SpFunc)      <$> func
+    <|> (return . SpRule)      <$> rule
+    <|> (return . SpStatement) <$> parseForStatement
 
-typeDef = withPos $ (TypeDef nopos) <$ reserved "typedef" <*> identifier <*>
-                                       (option [] (symbol "<" *> (commaSep $ symbol "'" *> typevarIdent) <* symbol ">")) <*>
-                                       (optionMaybe $ reservedOp "=" *> typeSpec)
+typeDef = (TypeDef nopos) <$ reserved "typedef" <*> identifier <*>
+                             (option [] (symbol "<" *> (commaSep $ symbol "'" *> typevarIdent) <* symbol ">")) <*>
+                             (optionMaybe $ reservedOp "=" *> typeSpec)
 
-func = withPos $ Function nopos <$  reserved "function"
-                                <*> funcIdent
-                                <*> (parens $ commaSep arg)
-                                <*> (colon *> typeSpecSimple)
-                                <*> (optionMaybe $ reservedOp "=" *> expr)
+func = Function nopos <$  reserved "function"
+                      <*> funcIdent
+                      <*> (parens $ commaSep arg)
+                      <*> (colon *> typeSpecSimple)
+                      <*> (optionMaybe $ reservedOp "=" *> expr)
 
-relation = withPos $ Relation nopos <$> ((True <$ reserved "ground" <* reserved "relation")
-                                         <|>
-                                         (False <$ reserved "relation"))
-                                       <*> relIdent <*> (parens $ commaSep arg)
-
+relation = do
+    ground <-  True <$ reserved "ground" <* reserved "relation" 
+           <|> False <$ reserved "relation"
+    relName <- relIdent
+    parens $
+        do try $ lookAhead arg
+           start <- getPosition
+           fields <- commaSep arg
+           end <- getPosition
+           let p = (start, end)
+           let tspec = TStruct p [Constructor p relName fields]
+           let tdef = TypeDef nopos relName [] $ Just tspec
+           let rel = Relation nopos ground relName $ TUser p relName []
+           return [SpType tdef, SpRelation rel]
+        <|>
+        do rel <- Relation nopos ground relName <$> typeSpec
+           return [SpRelation rel]
+        
 arg = withPos $ (Field nopos) <$> varIdent <*> (colon *> typeSpecSimple)
 
-parseForStatement = withPos $ ForStatement nopos <$ reserved "for"
-                                                 <*> (symbol "(" *> expr)
-                                                 <*> (reserved "in" *> relIdent)
-                                                 <*> (optionMaybe (reserved "if" *> expr))
-                                                 <*> (symbol ")" *> statement)
+parseForStatement = ForStatement nopos <$ reserved "for"
+                                       <*> (symbol "(" *> expr)
+                                       <*> (reserved "in" *> relIdent)
+                                       <*> (optionMaybe (reserved "if" *> expr))
+                                       <*> (symbol ")" *> statement)
 
 statement = parseForStatement
         <|> parseEmptyStatement
@@ -239,8 +268,7 @@ parseEmptyStatement = withPos $ (EmptyStatement nopos) <$ reserved "skip"
 parseBlockStatement = withPos $ (BlockStatement nopos) <$> (braces $ semiSep statement)
 
 parseIfStatement = withPos $ (IfStatement nopos) <$ reserved "if"
-                                                <*> (symbol "(" *> expr)
-                                                <*> (symbol ")" *> statement)
+                                                <*> (parens expr) <*> statement
                                                 <*> (optionMaybe (reserved "else" *> statement))
 
 parseMatchStatement = withPos $ (MatchStatement nopos) <$ reserved "match" <*> parens expr
@@ -250,14 +278,13 @@ parseLetStatement = withPos $ (LetStatement nopos) <$ reserved "let"
                                                   <*> commaSep parseAssignment
                                                   <*> (reserved "in" *> statement)
 
-parseInsertStatement = withPos $ (InsertStatement nopos) <$> relIdent
-                                                         <*> (parens $ commaSep expr)
+parseInsertStatement = withPos $ (InsertStatement nopos) <$> atom
 
-rule = withPos $ Rule nopos <$>
-                 (commaSep1 atom) <*>
-                 (option [] (reservedOp ":-" *> commaSep rulerhs)) <* dot
+rule = Rule nopos <$>
+       (commaSep1 atom) <*>
+       (option [] (reservedOp ":-" *> commaSep rulerhs)) <* dot
 
-rulerhs =  (do _ <- try $ lookAhead $ (optional $ reserved "not") *> relIdent *> symbol "("
+rulerhs =  (do _ <- try $ lookAhead $ (optional $ reserved "not") *> relIdent *> (symbol "(" <|> symbol "[")
                RHSLiteral <$> (option True (False <$ reserved "not")) <*> atom)
        <|> (RHSCondition <$> expr)
        <|> (RHSAggregate <$ reserved "Aggregate" <*>
@@ -268,7 +295,12 @@ rulerhs =  (do _ <- try $ lookAhead $ (optional $ reserved "not") *> relIdent *>
        <|> (RHSFlatMap <$ reserved "FlatMap" <*> (symbol "(" *> varIdent) <*>
                           (reservedOp "=" *> expr <* symbol ")"))
 
-atom = withPos $ Atom nopos <$> relIdent <*> (parens $ commaSep (namedarg <|> anonarg))
+atom = withPos $ do
+       rname <- relIdent
+       val <- (withPos $ eStruct rname <$> (parens $ commaSep (namedarg <|> anonarg)))
+              <|>
+              brackets expr
+       return $ Atom nopos rname val 
 
 anonarg = ("",) <$> expr
 namedarg = (,) <$> (dot *> varIdent) <*> (reservedOp "=" *> expr)

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -239,8 +239,7 @@ relation = do
          let rel = Relation nopos ground relName $ TUser p relName []
          return [SpType tdef, SpRelation rel])
       <|>
-       (do colon
-           rel <- Relation nopos ground relName <$> typeSpec
+       (do rel <- brackets $ Relation nopos ground relName <$> typeSpec
            return [SpRelation rel]))
         
 arg = withPos $ (Field nopos) <$> varIdent <*> (colon *> typeSpecSimple)

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -239,7 +239,7 @@ relation = do
          let rel = Relation nopos ground relName $ TUser p relName []
          return [SpType tdef, SpRelation rel])
       <|>
-       (do rel <- brackets $ Relation nopos ground relName <$> typeSpec
+       (do rel <- brackets $ Relation nopos ground relName <$> typeSpecSimple
            return [SpRelation rel]))
         
 arg = withPos $ (Field nopos) <$> varIdent <*> (colon *> typeSpecSimple)

--- a/src/Language/DifferentialDatalog/Rule.hs
+++ b/src/Language/DifferentialDatalog/Rule.hs
@@ -76,7 +76,7 @@ exprDecls d ctx e =
 
 exprVarTypes :: DatalogProgram -> ECtx -> Expr -> [Field]
 exprVarTypes d ctx e = 
-    map (\(v, ctx) -> Field nopos v $ exprType' d ctx (eVar v)) 
+    map (\(v, ctx) -> Field nopos v $ exprType d ctx (eVar v)) 
         $ exprVars ctx e
 
 atomVarDecls :: DatalogProgram -> Rule -> Int -> S.Set Field

--- a/src/Language/DifferentialDatalog/Rule.hs
+++ b/src/Language/DifferentialDatalog/Rule.hs
@@ -82,8 +82,8 @@ exprVarTypes d ctx e =
 atomVarDecls :: DatalogProgram -> Rule -> Int -> S.Set Field
 atomVarDecls d rl i = 
     S.fromList
-        $ concatMap (\(f,v) -> exprVarTypes d (CtxRuleRAtom rl i f) v) 
-        $ atomArgs $ rhsAtom $ ruleRHS rl !! i
+        $ exprVarTypes d (CtxRuleRAtom rl i) 
+        $ atomVal $ rhsAtom $ ruleRHS rl !! i
  
 -- | All variables defined in a rule
 ruleVars :: DatalogProgram -> Rule -> [Field]

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -325,7 +325,7 @@ instance WithName Relation where
     name = relName
 
 instance PP Relation where
-    pp Relation{..} = (if relGround then "ground" else empty) <+> "relation" <+> pp relName <+> "(" <> pp relType <> ")"
+    pp Relation{..} = (if relGround then "ground" else empty) <+> "relation" <+> pp relName <+> ":" <+> pp relType
 
 instance Show Relation where
     show = render . pp

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -325,7 +325,8 @@ instance WithName Relation where
     name = relName
 
 instance PP Relation where
-    pp Relation{..} = (if relGround then "ground" else empty) <+> "relation" <+> pp relName <+> ":" <+> pp relType
+    pp Relation{..} = (if relGround then "ground" else empty) <+> 
+                      "relation" <+> pp relName <+> "[" <> pp relType <> "]"
 
 instance Show Relation where
     show = render . pp

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -422,12 +422,10 @@ typeUserTypes' _           = []
 ctxExpectType :: DatalogProgram -> ECtx -> Maybe Type
 ctxExpectType _ CtxTop                               = Nothing
 ctxExpectType _ (CtxFunc f)                          = Just $ funcType f
-ctxExpectType d (CtxRuleL Rule{..} i fname)          = 
-    let rel = getRelation d (atomRelation $ ruleLHS !! i)
-    in fmap fieldType $ find ((== fname) . name) $ relArgs rel
-ctxExpectType d (CtxRuleRAtom Rule{..} i fname)      =
-    let rel = getRelation d (atomRelation $ rhsAtom $ ruleRHS !! i)
-    in fmap fieldType $ find ((== fname) . name) $ relArgs rel
+ctxExpectType d (CtxRuleL Rule{..} i)                = 
+    Just $ relType $ getRelation d (atomRelation $ ruleLHS !! i)
+ctxExpectType d (CtxRuleRAtom Rule{..} i)            =
+    Just $ relType $ getRelation d (atomRelation $ rhsAtom $ ruleRHS !! i)
 ctxExpectType _ (CtxRuleRCond Rule{..} i)            =
     case rhsExpr $ ruleRHS !! i of
          E ESet{} -> Just $ tTuple []

--- a/test/datalog_tests/ovn-ftl.ast.expected
+++ b/test/datalog_tests/ovn-ftl.ast.expected
@@ -3,126 +3,126 @@ typedef stage = LS_IN_ACL{} | LS_OUT_ACL{} | LR_IN_ADMISSION{} | LR_IN_IP_INPUT{
 function __builtin_2string (x: 'X): string
 for (lr in Logical_Router)
     {
-        Flow ( lr, LR_IN_ADMISSION{}, 100, "vlan.present || eth.src[40]", "{ drop; }" )
+        Flow(lr, LR_IN_ADMISSION{}, 100, "vlan.present || eth.src[40]", "{ drop; }")
     }
 for (lrp in Logical_Router_Port if lrp.enabled)
     {
         let p = lrp.name, e = lrp.mac in
             {
-                Flow ( lrp.lr, LR_IN_ADMISSION{}, 50, (((("inport == " ++ p) ++ " && (eth.mcast || eth.dst == ") ++ e) ++ ")"), "{ next; }" )
+                Flow(lrp.lr, LR_IN_ADMISSION{}, 50, (((("inport == " ++ p) ++ " && (eth.mcast || eth.dst == ") ++ e) ++ ")"), "{ next; }")
             }
     }
 for (lr in Logical_Router)
     {
-        Flow ( lr, LR_IN_IP_INPUT{}, 100, "ip4.mcast ||\n           ip4.src == 255.255.255.255 ||\n           ip4.src == 127.0.0.0/8 ||\n           ip4.dst == 127.0.0.0/8 ||\n           ip4.src == 0.0.0.0/8 ||\n           ip4.dst == 0.0.0.0/8)", "{ drop; }" );
-        Flow ( lr, LR_IN_IP_INPUT{}, 90, "arp.op == 2", "put_arp(inport, arp.spa, arp.sha);" );
-        Flow ( lr, LR_IN_IP_INPUT{}, 50, "eth.bcast", "{ drop; }" );
-        Flow ( lr, LR_IN_IP_INPUT{}, 30, "ip4 && ip.ttl == {0, 1}", "{ drop; }" );
-        Flow ( lr, LR_IN_IP_INPUT{}, 90, "nd_na", "{ put_nd(inport, nd.target, nd.tll); }" );
-        Flow ( lr, LR_IN_IP_INPUT{}, 80, "nd_na", "{ put_nd(inport, ip6.src, nd.sll); }" );
-        Flow ( lr, LR_IN_IP_INPUT{}, 0, "1", "{ next; }" )
+        Flow(lr, LR_IN_IP_INPUT{}, 100, "ip4.mcast ||\n           ip4.src == 255.255.255.255 ||\n           ip4.src == 127.0.0.0/8 ||\n           ip4.dst == 127.0.0.0/8 ||\n           ip4.src == 0.0.0.0/8 ||\n           ip4.dst == 0.0.0.0/8)", "{ drop; }");
+        Flow(lr, LR_IN_IP_INPUT{}, 90, "arp.op == 2", "put_arp(inport, arp.spa, arp.sha);");
+        Flow(lr, LR_IN_IP_INPUT{}, 50, "eth.bcast", "{ drop; }");
+        Flow(lr, LR_IN_IP_INPUT{}, 30, "ip4 && ip.ttl == {0, 1}", "{ drop; }");
+        Flow(lr, LR_IN_IP_INPUT{}, 90, "nd_na", "{ put_nd(inport, nd.target, nd.tll); }");
+        Flow(lr, LR_IN_IP_INPUT{}, 80, "nd_na", "{ put_nd(inport, ip6.src, nd.sll); }");
+        Flow(lr, LR_IN_IP_INPUT{}, 0, "1", "{ next; }")
     }
 for (lr in Logical_Router)
     {
-        Flow ( lr, LR_IN_DEFRAG{}, 0, "1", "{ next; }" );
-        Flow ( lr, LR_IN_UNSNAT{}, 0, "1", "{ next; }" );
-        Flow ( lr, LR_OUT_SNAT{}, 0, "1", "{ next; }" );
-        Flow ( lr, LR_IN_DNAT{}, 0, "1", "{ next; }" )
+        Flow(lr, LR_IN_DEFRAG{}, 0, "1", "{ next; }");
+        Flow(lr, LR_IN_UNSNAT{}, 0, "1", "{ next; }");
+        Flow(lr, LR_OUT_SNAT{}, 0, "1", "{ next; }");
+        Flow(lr, LR_IN_DNAT{}, 0, "1", "{ next; }")
     }
 for (lr in Logical_Router)
     {
-        Flow ( lr, LR_IN_ARP_RESOLVE{}, 0, "ip4", "{ get_arp(outport, reg0); next; }" );
-        Flow ( lr, LR_IN_ARP_RESOLVE{}, 0, "ip6", "{ get_nd(outport, xxreg0); next; }" )
+        Flow(lr, LR_IN_ARP_RESOLVE{}, 0, "ip4", "{ get_arp(outport, reg0); next; }");
+        Flow(lr, LR_IN_ARP_RESOLVE{}, 0, "ip6", "{ get_nd(outport, xxreg0); next; }")
     }
 for (lr in Logical_Router)
     {
-        Flow ( lr, LR_IN_ARP_REQUEST{}, 100, "eth.dst == 00:00:00:00:00:00", "{\n        arp {\n            eth.dst = ff:ff:ff:ff:ff:ff;\n            arp.spa = reg1;\n            arp.tpa = reg0;\n            arp.op = 1;  /* ARP request */\n            output;\n        }\n    }" );
-        Flow ( lr, LR_IN_ARP_REQUEST{}, 0, "1", "{ output; }" )
+        Flow(lr, LR_IN_ARP_REQUEST{}, 100, "eth.dst == 00:00:00:00:00:00", "{\n        arp {\n            eth.dst = ff:ff:ff:ff:ff:ff;\n            arp.spa = reg1;\n            arp.tpa = reg0;\n            arp.op = 1;  /* ARP request */\n            output;\n        }\n    }");
+        Flow(lr, LR_IN_ARP_REQUEST{}, 0, "1", "{ output; }")
     }
 for (lrp in Logical_Router_Port if lrp.enabled)
     {
         let p = lrp.name in
             {
-                Flow ( lrp.lr, LR_OUT_DELIVERY{}, 100, (("outport == " ++ p) ++ ""), "{ output; }" )
+                Flow(lrp.lr, LR_OUT_DELIVERY{}, 100, (("outport == " ++ p) ++ ""), "{ output; }")
             }
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_ACL{}, 0, "1", "next;" );
-        Flow ( ls, LS_OUT_ACL{}, 0, "1", "next;" )
+        Flow(ls, LS_IN_ACL{}, 0, "1", "next;");
+        Flow(ls, LS_OUT_ACL{}, 0, "1", "next;")
     }
 for (ls in Logical_Switch if ls.has_stateful_acl)
     {
-        Flow ( ls, LS_IN_ACL{}, 1, "ip && (!ct.est || (ct.est && ct_label.blocked))", "{ reg0[1] = 1; next; }" );
-        Flow ( ls, LS_OUT_ACL{}, 1, "ip && (!ct.est || (ct.est && ct_label.blocked))", "{ reg0[1] = 1; next; }" );
-        Flow ( ls, LS_IN_ACL{}, 65535, "ct.inv || (ct.est && ct.rpl && ct_label.blocked)", "{ drop; }" );
-        Flow ( ls, LS_OUT_ACL{}, 65535, "ct.inv || (ct.est && ct.rpl && ct_label.blocked)", "{ drop; };" );
-        Flow ( ls, LS_IN_ACL{}, 65535, "(ct.est && !ct.rel && !ct.new && !ct.inv && ct.rpl && !ct_label.blocked)", "{ next; }" );
-        Flow ( ls, LS_OUT_ACL{}, 65535, "(ct.est && !ct.rel && !ct.new && !ct.inv && ct.rpl && !ct_label.blocked)", "{ next; }" );
-        Flow ( ls, LS_IN_ACL{}, 65535, "!ct.est && ct.rel && !ct.new && !ct.inv && !ct_label.blocked", "{ next; }" );
-        Flow ( ls, LS_OUT_ACL{}, 65535, "!ct.est && ct.rel && !ct.new && !ct.inv && !ct_label.blocked", "{ next; }" );
-        Flow ( ls, LS_IN_ACL{}, 65535, "nd", "{ next; }" );
-        Flow ( ls, LS_OUT_ACL{}, 65535, "nd", "{ next; }" )
+        Flow(ls, LS_IN_ACL{}, 1, "ip && (!ct.est || (ct.est && ct_label.blocked))", "{ reg0[1] = 1; next; }");
+        Flow(ls, LS_OUT_ACL{}, 1, "ip && (!ct.est || (ct.est && ct_label.blocked))", "{ reg0[1] = 1; next; }");
+        Flow(ls, LS_IN_ACL{}, 65535, "ct.inv || (ct.est && ct.rpl && ct_label.blocked)", "{ drop; }");
+        Flow(ls, LS_OUT_ACL{}, 65535, "ct.inv || (ct.est && ct.rpl && ct_label.blocked)", "{ drop; };");
+        Flow(ls, LS_IN_ACL{}, 65535, "(ct.est && !ct.rel && !ct.new && !ct.inv && ct.rpl && !ct_label.blocked)", "{ next; }");
+        Flow(ls, LS_OUT_ACL{}, 65535, "(ct.est && !ct.rel && !ct.new && !ct.inv && ct.rpl && !ct_label.blocked)", "{ next; }");
+        Flow(ls, LS_IN_ACL{}, 65535, "!ct.est && ct.rel && !ct.new && !ct.inv && !ct_label.blocked", "{ next; }");
+        Flow(ls, LS_OUT_ACL{}, 65535, "!ct.est && ct.rel && !ct.new && !ct.inv && !ct_label.blocked", "{ next; }");
+        Flow(ls, LS_IN_ACL{}, 65535, "nd", "{ next; }");
+        Flow(ls, LS_OUT_ACL{}, 65535, "nd", "{ next; }")
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_LB{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_OUT_LB{}, 0, "1", "{ next; }" );
+        Flow(ls, LS_IN_LB{}, 0, "1", "{ next; }");
+        Flow(ls, LS_OUT_LB{}, 0, "1", "{ next; }");
         if (ls.has_load_balancer)
             {
-                Flow ( ls, LS_IN_LB{}, 65535, "ct.est && !ct.rel && !ct.new && !ct.inv", "\n            reg0[0] = 1;\n            next;\n        };" );
-                Flow ( ls, LS_OUT_LB{}, 65535, "ct.est && !ct.rel && !ct.new && !ct.inv", "\n            reg0[0] = 1;\n            next;\n        };" )
+                Flow(ls, LS_IN_LB{}, 65535, "ct.est && !ct.rel && !ct.new && !ct.inv", "\n            reg0[0] = 1;\n            next;\n        };");
+                Flow(ls, LS_OUT_LB{}, 65535, "ct.est && !ct.rel && !ct.new && !ct.inv", "\n            reg0[0] = 1;\n            next;\n        };")
             }
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_PRE_ACL{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_OUT_PRE_ACL{}, 0, "1", "{ next; }" )
+        Flow(ls, LS_IN_PRE_ACL{}, 0, "1", "{ next; }");
+        Flow(ls, LS_OUT_PRE_ACL{}, 0, "1", "{ next; }")
     }
 for (ls in Logical_Switch if ls.has_stateful_acl)
     {
-        Flow ( ls, LS_IN_PRE_ACL{}, 110, "nd", "{ next; }" );
-        Flow ( ls, LS_OUT_PRE_ACL{}, 110, "nd", "{ next; }" );
-        Flow ( ls, LS_IN_PRE_ACL{}, 100, "ip", "{ reg0[0] = 1; next; }" );
-        Flow ( ls, LS_OUT_PRE_ACL{}, 100, "ip", "{ reg0[0] = 1; next; }" )
+        Flow(ls, LS_IN_PRE_ACL{}, 110, "nd", "{ next; }");
+        Flow(ls, LS_OUT_PRE_ACL{}, 110, "nd", "{ next; }");
+        Flow(ls, LS_IN_PRE_ACL{}, 100, "ip", "{ reg0[0] = 1; next; }");
+        Flow(ls, LS_OUT_PRE_ACL{}, 100, "ip", "{ reg0[0] = 1; next; }")
     }
 for (lb in Load_Balancer)
     {
         let a = lb.ip_addresses in
-            Flow ( lb.ls, LS_IN_PRE_LB{}, 100, "ip4.dst == ${a}", "{ reg0[0] = 1; next; }" )
+            Flow(lb.ls, LS_IN_PRE_LB{}, 100, "ip4.dst == ${a}", "{ reg0[0] = 1; next; }")
     }
 for (ls in Logical_Switch)
     {
         if (ls.has_load_balancer)
             {
-                Flow ( ls, LS_OUT_PRE_LB{}, 100, "ip4", "{ reg0[0] = 1; next; }" )
+                Flow(ls, LS_OUT_PRE_LB{}, 100, "ip4", "{ reg0[0] = 1; next; }")
             }
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_PRE_LB{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_OUT_PRE_LB{}, 0, "1", "{ next; }" )
+        Flow(ls, LS_IN_PRE_LB{}, 0, "1", "{ next; }");
+        Flow(ls, LS_OUT_PRE_LB{}, 0, "1", "{ next; }")
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_PRE_STATEFUL{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_OUT_PRE_STATEFUL{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_IN_PRE_STATEFUL{}, 100, "reg0[0] /* conntrack.defrag */", "{ ct_next; }" );
-        Flow ( ls, LS_OUT_PRE_STATEFUL{}, 100, "reg0[0] /* conntrack.defrag */", "{ ct_next; }" )
+        Flow(ls, LS_IN_PRE_STATEFUL{}, 0, "1", "{ next; }");
+        Flow(ls, LS_OUT_PRE_STATEFUL{}, 0, "1", "{ next; }");
+        Flow(ls, LS_IN_PRE_STATEFUL{}, 100, "reg0[0] /* conntrack.defrag */", "{ ct_next; }");
+        Flow(ls, LS_OUT_PRE_STATEFUL{}, 100, "reg0[0] /* conntrack.defrag */", "{ ct_next; }")
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_STATEFUL{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_OUT_STATEFUL{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_IN_STATEFUL{}, 100, "reg0[1] == 1", "{\n        ct_commit(ct_label=0/1);\n        next;\n    }" );
-        Flow ( ls, LS_OUT_STATEFUL{}, 100, "reg0[1] == 1", "{\n        ct_commit(ct_label=0/1);\n        next;\n    }" );
-        Flow ( ls, LS_IN_STATEFUL{}, 100, "reg0[2] == 1", "{ ct_lb; }" );
-        Flow ( ls, LS_OUT_STATEFUL{}, 100, "reg0[2] == 1", "{ ct_lb; }" )
+        Flow(ls, LS_IN_STATEFUL{}, 0, "1", "{ next; }");
+        Flow(ls, LS_OUT_STATEFUL{}, 0, "1", "{ next; }");
+        Flow(ls, LS_IN_STATEFUL{}, 100, "reg0[1] == 1", "{\n        ct_commit(ct_label=0/1);\n        next;\n    }");
+        Flow(ls, LS_OUT_STATEFUL{}, 100, "reg0[1] == 1", "{\n        ct_commit(ct_label=0/1);\n        next;\n    }");
+        Flow(ls, LS_IN_STATEFUL{}, 100, "reg0[2] == 1", "{ ct_lb; }");
+        Flow(ls, LS_OUT_STATEFUL{}, 100, "reg0[2] == 1", "{ ct_lb; }")
     }
 for (lsp in Logical_Switch_Port)
     {
-        Flow ( lsp.ls, LS_IN_PORT_SEC_L2{}, 100, "vlan.present", "{ drop; }" );
-        Flow ( lsp.ls, LS_IN_PORT_SEC_L2{}, 100, "eth.src[40]", "{ drop; }" )
+        Flow(lsp.ls, LS_IN_PORT_SEC_L2{}, 100, "vlan.present", "{ drop; }");
+        Flow(lsp.ls, LS_IN_PORT_SEC_L2{}, 100, "eth.src[40]", "{ drop; }")
     }
 for (lsp in Logical_Switch_Port if lsp.enabled)
     {
@@ -130,54 +130,54 @@ for (lsp in Logical_Switch_Port if lsp.enabled)
             {
                 if (lsp.port_security.not_empty)
                     {
-                        Flow ( lsp.ls, LS_IN_PORT_SEC_L2{}, 50, (((("inport == \"" ++ p) ++ "\" && eth.src == ") ++ l2) ++ ""), "{ next; }" );
-                        Flow ( lsp.ls, LS_IN_PORT_SEC_IP{}, 90, (((("inport == \"" ++ p) ++ "\" && (") ++ ip) ++ "))"), "{ next; }" );
-                        Flow ( lsp.ls, LS_IN_PORT_SEC_IP{}, 80, (((("inport == \"" ++ p) ++ "\" && ip && eth.src == ") ++ l2) ++ ""), "{ drop; }" );
-                        Flow ( lsp.ls, LS_IN_PORT_SEC_ND{}, 90, (((("inport == \"" ++ p) ++ "\" && (") ++ nd) ++ ")"), "{ next; }" );
-                        Flow ( lsp.ls, LS_IN_PORT_SEC_ND{}, 80, (("inport == \"" ++ p) ++ "\" && (arp || nd)"), "{ drop; }" )
+                        Flow(lsp.ls, LS_IN_PORT_SEC_L2{}, 50, (((("inport == \"" ++ p) ++ "\" && eth.src == ") ++ l2) ++ ""), "{ next; }");
+                        Flow(lsp.ls, LS_IN_PORT_SEC_IP{}, 90, (((("inport == \"" ++ p) ++ "\" && (") ++ ip) ++ "))"), "{ next; }");
+                        Flow(lsp.ls, LS_IN_PORT_SEC_IP{}, 80, (((("inport == \"" ++ p) ++ "\" && ip && eth.src == ") ++ l2) ++ ""), "{ drop; }");
+                        Flow(lsp.ls, LS_IN_PORT_SEC_ND{}, 90, (((("inport == \"" ++ p) ++ "\" && (") ++ nd) ++ ")"), "{ next; }");
+                        Flow(lsp.ls, LS_IN_PORT_SEC_ND{}, 80, (("inport == \"" ++ p) ++ "\" && (arp || nd)"), "{ drop; }")
                     }
                 else
                     {
-                        Flow ( lsp.ls, LS_IN_PORT_SEC_L2{}, 50, (("inport == \"" ++ p) ++ "\""), "{ next; }" )
+                        Flow(lsp.ls, LS_IN_PORT_SEC_L2{}, 50, (("inport == \"" ++ p) ++ "\""), "{ next; }")
                     }
             }
     }
 for (lsp in Logical_Switch_Port)
     {
-        Flow ( lsp.ls, LS_IN_PORT_SEC_ND{}, 0, "1", "{ next; }" );
-        Flow ( lsp.ls, LS_IN_PORT_SEC_IP{}, 0, "1", "{ next; }" )
+        Flow(lsp.ls, LS_IN_PORT_SEC_ND{}, 0, "1", "{ next; }");
+        Flow(lsp.ls, LS_IN_PORT_SEC_IP{}, 0, "1", "{ next; }")
     }
 for (lsp in Logical_Switch_Port)
     if ((lsp.type == "localnet"))
         {
             let p = lsp.name in
-                Flow ( lsp.ls, LS_IN_ARP_RSP{}, 100, (("inport == \"" ++ p) ++ "\""), "{ next; }" )
+                Flow(lsp.ls, LS_IN_ARP_RSP{}, 100, (("inport == \"" ++ p) ++ "\""), "{ next; }")
         }
 for (ls in Logical_Switch)
-    Flow ( ls, LS_IN_ARP_RSP{}, 0, "1", "{ next; }" )
+    Flow(ls, LS_IN_ARP_RSP{}, 0, "1", "{ next; }")
 for (lspip in Logical_Switch_Port_IP if lspip.lsp.up)
     {
         let e = lspip.mac, a = lspip.ip, p = lspip.lsp.name in
             {
                 if ((lspip.ip_version == 4))
                     {
-                        Flow ( lspip.lsp.ls, LS_IN_ARP_RSP{}, "50", (((((((("\n                arp.tpa == " ++ a) ++ " && arp.op == 1) {\n                eth.dst = eth.src;\n                eth.src = ") ++ e) ++ ";\n                arp.op = 2;     /* ARP reply */\n                arp.tha = arp.sha;\n                arp.sha = ") ++ e) ++ ";\n                arp.tpa = arp.spa;\n                arp.spa = ") ++ a) ++ ";\n                outport = inport;\n                flags.loopback = 1;\n                output;\n            };") );
-                        Flow ( lspip.lsp.ls, LS_IN_ARP_RSP{}, 100, (((("arp.tpa == " ++ a) ++ " && arp.op == 1 && inport == \"") ++ p) ++ "\""), "{ next; }" )
+                        Flow(lspip.lsp.ls, LS_IN_ARP_RSP{}, "50", (((((((("\n                arp.tpa == " ++ a) ++ " && arp.op == 1) {\n                eth.dst = eth.src;\n                eth.src = ") ++ e) ++ ";\n                arp.op = 2;     /* ARP reply */\n                arp.tha = arp.sha;\n                arp.sha = ") ++ e) ++ ";\n                arp.tpa = arp.spa;\n                arp.spa = ") ++ a) ++ ";\n                outport = inport;\n                flags.loopback = 1;\n                output;\n            };"));
+                        Flow(lspip.lsp.ls, LS_IN_ARP_RSP{}, 100, (((("arp.tpa == " ++ a) ++ " && arp.op == 1 && inport == \"") ++ p) ++ "\""), "{ next; }")
                     }
                 else
                     {
                         let s = lspip.sn_ip in
                             {
-                                Flow ( lspip.lsp.ls, LS_IN_ARP_RSP{}, 50, (((((("nd_ns && ip6.dst == {" ++ a) ++ ", ") ++ s) ++ "} && nd.target == ") ++ a) ++ ""), (((((((("{\n                     nd_na {\n                        eth.src = " ++ e) ++ ";\n                        ip6.src = ") ++ a) ++ ";\n                        nd.target = ") ++ a) ++ ";\n                        nd.tll = ") ++ e) ++ ";\n                        outport = inport;\n                        flags.loopback = 1;\n                        output;\n                    };\n                }") );
-                                Flow ( lspip.lsp.ls, LS_IN_ARP_RSP{}, 100, " nd_ns && ip6.dst == {${a}, ${s}} && nd.target == ${a}\n                     && inport == \\\"${p}\\\"", "{ next; }" )
+                                Flow(lspip.lsp.ls, LS_IN_ARP_RSP{}, 50, (((((("nd_ns && ip6.dst == {" ++ a) ++ ", ") ++ s) ++ "} && nd.target == ") ++ a) ++ ""), (((((((("{\n                     nd_na {\n                        eth.src = " ++ e) ++ ";\n                        ip6.src = ") ++ a) ++ ";\n                        nd.target = ") ++ a) ++ ";\n                        nd.tll = ") ++ e) ++ ";\n                        outport = inport;\n                        flags.loopback = 1;\n                        output;\n                    };\n                }"));
+                                Flow(lspip.lsp.ls, LS_IN_ARP_RSP{}, 100, " nd_ns && ip6.dst == {${a}, ${s}} && nd.target == ${a}\n                     && inport == \\\"${p}\\\"", "{ next; }")
                             }
                     }
             }
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_DHCP_OPTIONS{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_IN_DHCP_RESPONSE{}, 0, "1", "{ next; }" )
+        Flow(ls, LS_IN_DHCP_OPTIONS{}, 0, "1", "{ next; }");
+        Flow(ls, LS_IN_DHCP_RESPONSE{}, 0, "1", "{ next; }")
     }
 for (lspip in Logical_Switch_Port_IP if (lspip.lsp.enabled and (lspip.lsp.type != "router")))
     {
@@ -189,8 +189,8 @@ for (lspip in Logical_Switch_Port_IP if (lspip.lsp.enabled and (lspip.lsp.type !
                             {
                                 let m = lspip.lsp.dhcpv4_options.netmask, o = lspip.lsp.dhcpv4_options.option_args, sm = lspip.lsp.dhcpv4_options.server_mac, si = lspip.lsp.dhcpv4_options.server_ip in
                                     {
-                                        Flow ( lspip.lsp.ls, LS_IN_DHCP_OPTIONS{}, 100, " inport == \"${p}\" && eth.src == ${e}\n                         && ip4.src == 0.0.0.0 && ip4.dst == 255.255.255.255\n                         && udp.src == 68 && udp.dst == 67", "{\n                        reg0[3] = put_dhcp_opts(offerip = ${a},\n                                                netmask = ${m},\n                                                ${o}); next; }" );
-                                        Flow ( lspip.lsp.ls, LS_IN_DHCP_RESPONSE{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                         && ip4.src == 0.0.0.0 && ip4.dst == 255.255.255.255\n                         && udp.src == 68 && udp.dst == 67\n                         && reg0[3]", "{\n                        eth.dst = eth.src;\n                        eth.src = ${sm};\n                        ip4.dst = ${a};\n                        ip4.src = ${si};\n                        udp.src = 67;\n                        udp.dst = 68;\n                        outport = inport;\n                        flags.loopback = 1;\n                        output;\n                    };" )
+                                        Flow(lspip.lsp.ls, LS_IN_DHCP_OPTIONS{}, 100, " inport == \"${p}\" && eth.src == ${e}\n                         && ip4.src == 0.0.0.0 && ip4.dst == 255.255.255.255\n                         && udp.src == 68 && udp.dst == 67", "{\n                        reg0[3] = put_dhcp_opts(offerip = ${a},\n                                                netmask = ${m},\n                                                ${o}); next; }");
+                                        Flow(lspip.lsp.ls, LS_IN_DHCP_RESPONSE{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                         && ip4.src == 0.0.0.0 && ip4.dst == 255.255.255.255\n                         && udp.src == 68 && udp.dst == 67\n                         && reg0[3]", "{\n                        eth.dst = eth.src;\n                        eth.src = ${sm};\n                        ip4.dst = ${a};\n                        ip4.src = ${si};\n                        udp.src = 67;\n                        udp.dst = 68;\n                        outport = inport;\n                        flags.loopback = 1;\n                        output;\n                    };")
                                     }
                             }
                     }
@@ -200,20 +200,20 @@ for (lspip in Logical_Switch_Port_IP if (lspip.lsp.enabled and (lspip.lsp.type !
                             {
                                 if (lspip.lsp.dhcpv6_options.stateful)
                                     {
-                                        Flow ( lspip.lsp.ls, LS_IN_DHCP_OPTIONS{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                         && ip6.dst == ff02::1:2\n                         && udp.src == 546 && udp.dst == 547)", "{\n                        reg0[3] = put_dhcpv6_opts(ia_addr = ${a}, ${o});\n                        next;\n                    }" )
+                                        Flow(lspip.lsp.ls, LS_IN_DHCP_OPTIONS{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                         && ip6.dst == ff02::1:2\n                         && udp.src == 546 && udp.dst == 547)", "{\n                        reg0[3] = put_dhcpv6_opts(ia_addr = ${a}, ${o});\n                        next;\n                    }")
                                     }
                                 else
                                     {
-                                        Flow ( lspip.lsp.ls, LS_IN_DHCP_OPTIONS{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                         && ip6.dst == ff02::1:2\n                         && udp.src == 546 && udp.dst == 547)", "{\n                        reg0[3] = put_dhcpv6_opts(${o});\n                        next;\n                    }" )
+                                        Flow(lspip.lsp.ls, LS_IN_DHCP_OPTIONS{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                         && ip6.dst == ff02::1:2\n                         && udp.src == 546 && udp.dst == 547)", "{\n                        reg0[3] = put_dhcpv6_opts(${o});\n                        next;\n                    }")
                                     };
-                                Flow ( lspip.lsp.ls, LS_IN_DHCP_RESPONSE{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                     && ip6.dst == ff02::1:2\n                     && udp.src == 546 && udp.dst == 547\n                     && reg0[3]", "{\n                    eth.dst = eth.src;\n                    eth.src = ${sm};\n                    ip6.dst = ip6.src;\n                    ip6.src = ${si};\n                    udp.src = 547;\n                    udp.dst = 546;\n                    outport = inport;\n                    flags.loopback = 1;\n                    output;\n                };" )
+                                Flow(lspip.lsp.ls, LS_IN_DHCP_RESPONSE{}, 100, "inport == \"${p}\" && eth.src == ${e}\n                     && ip6.dst == ff02::1:2\n                     && udp.src == 546 && udp.dst == 547\n                     && reg0[3]", "{\n                    eth.dst = eth.src;\n                    eth.src = ${sm};\n                    ip6.dst = ip6.src;\n                    ip6.src = ${si};\n                    udp.src = 547;\n                    udp.dst = 546;\n                    outport = inport;\n                    flags.loopback = 1;\n                    output;\n                };")
                             }
                     }
             }
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_L2_LKUP{}, 100, "eth.mcast", "{\n        outport = \"_MC_flood\";\n        output;\n    };" )
+        Flow(ls, LS_IN_L2_LKUP{}, 100, "eth.mcast", "{\n        outport = \"_MC_flood\";\n        output;\n    };")
     }
 for (lsp in Logical_Switch_Port)
     {
@@ -221,13 +221,13 @@ for (lsp in Logical_Switch_Port)
             {
                 let P = lsp.name, M = lsp.macs in
                     {
-                        Flow ( lsp.ls, LS_IN_L2_LKUP{}, 50, (("eth.dst == {" ++ M{}) ++ "}"), "{\n                outport = \"${P}\";\n                output;\n            }" )
+                        Flow(lsp.ls, LS_IN_L2_LKUP{}, 50, (("eth.dst == {" ++ M{}) ++ "}"), "{\n                outport = \"${P}\";\n                output;\n            }")
                     }
             }
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_IN_L2_LKUP{}, 0, "1", "{\n        outport = \"_MC_unknown\";\n        output;\n    }" )
+        Flow(ls, LS_IN_L2_LKUP{}, 0, "1", "{\n        outport = \"_MC_unknown\";\n        output;\n    }")
     }
 for (lsp in Logical_Switch_Port)
     {
@@ -235,21 +235,21 @@ for (lsp in Logical_Switch_Port)
             {
                 if (lsp.has_port_security)
                     {
-                        Flow ( lsp.ls, LS_OUT_PORT_SEC_IP{}, 90, (((("\"outport == \"" ++ p) ++ "\" && (") ++ ip) ++ ")"), "{ next; }" );
-                        Flow ( lsp.ls, LS_OUT_PORT_SEC_IP{}, 80, (((("\"outport == \"" ++ p) ++ "\" && ip && eth.dst == ") ++ l2) ++ ""), "{ drop; }" )
+                        Flow(lsp.ls, LS_OUT_PORT_SEC_IP{}, 90, (((("\"outport == \"" ++ p) ++ "\" && (") ++ ip) ++ ")"), "{ next; }");
+                        Flow(lsp.ls, LS_OUT_PORT_SEC_IP{}, 80, (((("\"outport == \"" ++ p) ++ "\" && ip && eth.dst == ") ++ l2) ++ ""), "{ drop; }")
                     };
                 if (lsp.enabled)
                     {
-                        Flow ( lsp.ls, LS_OUT_PORT_SEC_L2{}, 50, (((("outport == \"" ++ p) ++ "\" && eth.dst == ") ++ l2) ++ ""), "{ output; }" )
+                        Flow(lsp.ls, LS_OUT_PORT_SEC_L2{}, 50, (((("outport == \"" ++ p) ++ "\" && eth.dst == ") ++ l2) ++ ""), "{ output; }")
                     }
                 else
                     {
-                        Flow ( lsp.ls, LS_OUT_PORT_SEC_L2{}, 150, (("outport == \"" ++ p) ++ "\""), "{ drop; }" )
+                        Flow(lsp.ls, LS_OUT_PORT_SEC_L2{}, 150, (("outport == \"" ++ p) ++ "\""), "{ drop; }")
                     }
             }
     }
 for (ls in Logical_Switch)
     {
-        Flow ( ls, LS_OUT_PORT_SEC_IP{}, 0, "1", "{ next; }" );
-        Flow ( ls, LS_OUT_PORT_SEC_L2{}, 100, "eth.mcast", "{ output; }" )
+        Flow(ls, LS_OUT_PORT_SEC_IP{}, 0, "1", "{ next; }");
+        Flow(ls, LS_OUT_PORT_SEC_L2{}, 100, "eth.mcast", "{ output; }")
     }

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -92,67 +92,67 @@ function is_some (x: option_t<'A>): bool =
         Some{.value=_} -> true,
         _ -> false
     }
-ground relation ACL (ACL)
-ground relation ACL_external_ids (ACL_external_ids)
-ground relation Address_Set (Address_Set)
-ground relation Address_Set_addresses (Address_Set_addresses)
-ground relation Address_Set_external_ids (Address_Set_external_ids)
-ground relation Connection (Connection)
-ground relation Connection_external_ids (Connection_external_ids)
-ground relation Connection_other_config (Connection_other_config)
-ground relation Connection_status (Connection_status)
-ground relation DHCP_Options (DHCP_Options)
-ground relation DHCP_Options_external_ids (DHCP_Options_external_ids)
-relation DHCP_Options_netmask (DHCP_Options_netmask)
-relation DHCP_Options_option_args (DHCP_Options_option_args)
-ground relation DHCP_Options_options (DHCP_Options_options)
-relation DHCP_Options_server_ip (DHCP_Options_server_ip)
-relation DHCP_Options_server_mac (DHCP_Options_server_mac)
-relation DHCP_Options_stateful (DHCP_Options_stateful)
-ground relation DNS (DNS)
-ground relation DNS_external_ids (DNS_external_ids)
-ground relation DNS_records (DNS_records)
-ground relation Gateway_Chassis (Gateway_Chassis)
-ground relation Gateway_Chassis_external_ids (Gateway_Chassis_external_ids)
-ground relation Gateway_Chassis_options (Gateway_Chassis_options)
-ground relation Load_Balancer (Load_Balancer)
-ground relation Load_Balancer_external_ids (Load_Balancer_external_ids)
-relation Load_Balancer_ip_addresses (Load_Balancer_ip_addresses)
-ground relation Load_Balancer_vips (Load_Balancer_vips)
-ground relation Logical_Router (Logical_Router)
-ground relation Logical_Router_Port (Logical_Router_Port)
-ground relation Logical_Router_Port_external_ids (Logical_Router_Port_external_ids)
-ground relation Logical_Router_Port_ipv6_ra_configs (Logical_Router_Port_ipv6_ra_configs)
-ground relation Logical_Router_Port_networks (Logical_Router_Port_networks)
-ground relation Logical_Router_Port_options (Logical_Router_Port_options)
-ground relation Logical_Router_Static_Route (Logical_Router_Static_Route)
-ground relation Logical_Router_Static_Route_external_ids (Logical_Router_Static_Route_external_ids)
-ground relation Logical_Router_external_ids (Logical_Router_external_ids)
-ground relation Logical_Router_options (Logical_Router_options)
-ground relation Logical_Switch (Logical_Switch)
-ground relation Logical_Switch_Port (Logical_Switch_Port)
-ground relation Logical_Switch_Port_addresses (Logical_Switch_Port_addresses)
-ground relation Logical_Switch_Port_dynamic_addresses (Logical_Switch_Port_dynamic_addresses)
-ground relation Logical_Switch_Port_external_ids (Logical_Switch_Port_external_ids)
-relation Logical_Switch_Port_ips (Logical_Switch_Port_ips)
-relation Logical_Switch_Port_macs (Logical_Switch_Port_macs)
-ground relation Logical_Switch_Port_options (Logical_Switch_Port_options)
-ground relation Logical_Switch_Port_port_security (Logical_Switch_Port_port_security)
-relation Logical_Switch_Port_ps_ips (Logical_Switch_Port_ps_ips)
-relation Logical_Switch_Port_ps_macs (Logical_Switch_Port_ps_macs)
-ground relation Logical_Switch_external_ids (Logical_Switch_external_ids)
-relation Logical_Switch_has_stateful_acl_action (Logical_Switch_has_stateful_acl_action)
-ground relation Logical_Switch_other_config (Logical_Switch_other_config)
-ground relation NAT (NAT)
-ground relation NAT_external_ids (NAT_external_ids)
-ground relation NB_Global (NB_Global)
-ground relation NB_Global_external_ids (NB_Global_external_ids)
-ground relation QoS (QoS)
-ground relation QoS_action (QoS_action)
-ground relation QoS_bandwidth (QoS_bandwidth)
-ground relation QoS_external_ids (QoS_external_ids)
-ground relation SSL (SSL)
-ground relation SSL_external_ids (SSL_external_ids)
+ground relation ACL : ACL
+ground relation ACL_external_ids : ACL_external_ids
+ground relation Address_Set : Address_Set
+ground relation Address_Set_addresses : Address_Set_addresses
+ground relation Address_Set_external_ids : Address_Set_external_ids
+ground relation Connection : Connection
+ground relation Connection_external_ids : Connection_external_ids
+ground relation Connection_other_config : Connection_other_config
+ground relation Connection_status : Connection_status
+ground relation DHCP_Options : DHCP_Options
+ground relation DHCP_Options_external_ids : DHCP_Options_external_ids
+relation DHCP_Options_netmask : DHCP_Options_netmask
+relation DHCP_Options_option_args : DHCP_Options_option_args
+ground relation DHCP_Options_options : DHCP_Options_options
+relation DHCP_Options_server_ip : DHCP_Options_server_ip
+relation DHCP_Options_server_mac : DHCP_Options_server_mac
+relation DHCP_Options_stateful : DHCP_Options_stateful
+ground relation DNS : DNS
+ground relation DNS_external_ids : DNS_external_ids
+ground relation DNS_records : DNS_records
+ground relation Gateway_Chassis : Gateway_Chassis
+ground relation Gateway_Chassis_external_ids : Gateway_Chassis_external_ids
+ground relation Gateway_Chassis_options : Gateway_Chassis_options
+ground relation Load_Balancer : Load_Balancer
+ground relation Load_Balancer_external_ids : Load_Balancer_external_ids
+relation Load_Balancer_ip_addresses : Load_Balancer_ip_addresses
+ground relation Load_Balancer_vips : Load_Balancer_vips
+ground relation Logical_Router : Logical_Router
+ground relation Logical_Router_Port : Logical_Router_Port
+ground relation Logical_Router_Port_external_ids : Logical_Router_Port_external_ids
+ground relation Logical_Router_Port_ipv6_ra_configs : Logical_Router_Port_ipv6_ra_configs
+ground relation Logical_Router_Port_networks : Logical_Router_Port_networks
+ground relation Logical_Router_Port_options : Logical_Router_Port_options
+ground relation Logical_Router_Static_Route : Logical_Router_Static_Route
+ground relation Logical_Router_Static_Route_external_ids : Logical_Router_Static_Route_external_ids
+ground relation Logical_Router_external_ids : Logical_Router_external_ids
+ground relation Logical_Router_options : Logical_Router_options
+ground relation Logical_Switch : Logical_Switch
+ground relation Logical_Switch_Port : Logical_Switch_Port
+ground relation Logical_Switch_Port_addresses : Logical_Switch_Port_addresses
+ground relation Logical_Switch_Port_dynamic_addresses : Logical_Switch_Port_dynamic_addresses
+ground relation Logical_Switch_Port_external_ids : Logical_Switch_Port_external_ids
+relation Logical_Switch_Port_ips : Logical_Switch_Port_ips
+relation Logical_Switch_Port_macs : Logical_Switch_Port_macs
+ground relation Logical_Switch_Port_options : Logical_Switch_Port_options
+ground relation Logical_Switch_Port_port_security : Logical_Switch_Port_port_security
+relation Logical_Switch_Port_ps_ips : Logical_Switch_Port_ps_ips
+relation Logical_Switch_Port_ps_macs : Logical_Switch_Port_ps_macs
+ground relation Logical_Switch_external_ids : Logical_Switch_external_ids
+relation Logical_Switch_has_stateful_acl_action : Logical_Switch_has_stateful_acl_action
+ground relation Logical_Switch_other_config : Logical_Switch_other_config
+ground relation NAT : NAT
+ground relation NAT_external_ids : NAT_external_ids
+ground relation NB_Global : NB_Global
+ground relation NB_Global_external_ids : NB_Global_external_ids
+ground relation QoS : QoS
+ground relation QoS_action : QoS_action
+ground relation QoS_bandwidth : QoS_bandwidth
+ground relation QoS_external_ids : QoS_external_ids
+ground relation SSL : SSL
+ground relation SSL_external_ids : SSL_external_ids
 Load_Balancer_ip_addresses(.load_balancer=lb, .ip_address=ip_address_and_port_from_lb_key(key).ip) :- Load_Balancer_vips(.load_balancer=lb, .key=key, .value=_).
 Logical_Switch_Port_ips(.logical_switch_port=lsp, .mac=mac, .ip=ip) :- Logical_Switch_Port_addresses(.logical_switch_port=lsp, .address=addrs), (var mac, var ips) = extract_mac(addrs), FlatMap(ip = extract_ips(ips)).
 Logical_Switch_Port_ips(.logical_switch_port=lsp, .mac=mac, .ip=ip) :- Logical_Switch_Port_dynamic_addresses(.logical_switch_port=lsp, .dynamic_address=addrs), (var mac, var ips) = extract_mac(addrs), FlatMap(ip = extract_ips(ips)).

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -1,3 +1,64 @@
+typedef ACL = ACL{id: uuid, name: option_t<string>, logical_switch: uuid, priority: int, direction: string, _match: string, action: string, log: bool, severity: option_t<string>}
+typedef ACL_external_ids = ACL_external_ids{acl: uuid, key: string, value: string}
+typedef Address_Set = Address_Set{id: uuid, name: string}
+typedef Address_Set_addresses = Address_Set_addresses{address_set: uuid, address: string}
+typedef Address_Set_external_ids = Address_Set_external_ids{address_set: uuid, key: string, value: string}
+typedef Connection = Connection{id: uuid, target: string, is_connected: bool, max_backoff: option_t<int>, inactivity_probe: option_t<int>}
+typedef Connection_external_ids = Connection_external_ids{connection: uuid, value: string}
+typedef Connection_other_config = Connection_other_config{connection: uuid, other_config: string}
+typedef Connection_status = Connection_status{connection: uuid, key: string, value: string}
+typedef DHCP_Options = DHCP_Options{id: uuid, cidr: string}
+typedef DHCP_Options_external_ids = DHCP_Options_external_ids{dhcp_options: uuid, key: string, value: string}
+typedef DHCP_Options_netmask = DHCP_Options_netmask{dhcp_options: uuid, netmask: string}
+typedef DHCP_Options_option_args = DHCP_Options_option_args{dhcp_options: uuid, option: string}
+typedef DHCP_Options_options = DHCP_Options_options{dhcp_options: uuid, key: string, value: string}
+typedef DHCP_Options_server_ip = DHCP_Options_server_ip{dhcp_options: uuid, server_ip: string}
+typedef DHCP_Options_server_mac = DHCP_Options_server_mac{dhcp_options: uuid, server_mac: mac_addr_t}
+typedef DHCP_Options_stateful = DHCP_Options_stateful{dhcp_options: uuid, stateful: bool}
+typedef DNS = DNS{id: uuid, logical_switch: uuid}
+typedef DNS_external_ids = DNS_external_ids{dns: uuid, key: string, value: string}
+typedef DNS_records = DNS_records{dns: uuid, key: string, value: string}
+typedef Gateway_Chassis = Gateway_Chassis{id: uuid, logical_router: uuid, name: string, chassis_name: string, priority: int}
+typedef Gateway_Chassis_external_ids = Gateway_Chassis_external_ids{gateway_chassis: uuid, key: string, value: string}
+typedef Gateway_Chassis_options = Gateway_Chassis_options{gateway_chassis: uuid, key: string, value: string}
+typedef Load_Balancer = Load_Balancer{id: uuid, logical_switch: uuid, protocol: option_t<string>, name: string}
+typedef Load_Balancer_external_ids = Load_Balancer_external_ids{load_balancer: uuid, key: string, value: string}
+typedef Load_Balancer_ip_addresses = Load_Balancer_ip_addresses{load_balancer: uuid, ip_address: string}
+typedef Load_Balancer_vips = Load_Balancer_vips{load_balancer: uuid, key: string, value: string}
+typedef Logical_Router = Logical_Router{id: uuid, enabled: option_t<bool>, name: string}
+typedef Logical_Router_Port = Logical_Router_Port{id: uuid, logical_router: uuid, name: string, mac: string, peer: option_t<string>, enabled: option_t<bool>}
+typedef Logical_Router_Port_external_ids = Logical_Router_Port_external_ids{logical_router_port: uuid, key: string, value: string}
+typedef Logical_Router_Port_ipv6_ra_configs = Logical_Router_Port_ipv6_ra_configs{logical_router_port: uuid, key: string, value: string}
+typedef Logical_Router_Port_networks = Logical_Router_Port_networks{logical_router_port: uuid, network: string}
+typedef Logical_Router_Port_options = Logical_Router_Port_options{logical_router_port: uuid, key: string, value: string}
+typedef Logical_Router_Static_Route = Logical_Router_Static_Route{id: uuid, logical_router: uuid, ip_prefix: string, policy: option_t<string>, nexthop: string, output_port: option_t<string>}
+typedef Logical_Router_Static_Route_external_ids = Logical_Router_Static_Route_external_ids{logical_router_static_route: uuid, key: string, value: string}
+typedef Logical_Router_external_ids = Logical_Router_external_ids{logical_router: uuid, key: string, value: string}
+typedef Logical_Router_options = Logical_Router_options{logical_router: uuid, key: string, value: string}
+typedef Logical_Switch = Logical_Switch{id: uuid, name: string, type: string}
+typedef Logical_Switch_Port = Logical_Switch_Port{id: uuid, logical_switch: uuid, parent: option_t<string>, tag_request: option_t<int>, tag: option_t<int>, up: option_t<bool>, enabled: option_t<bool>, dhcpv4_options: option_t<uuid>, dhcpv6_options: option_t<uuid>, name: string, type: string}
+typedef Logical_Switch_Port_addresses = Logical_Switch_Port_addresses{logical_switch_port: uuid, address: string}
+typedef Logical_Switch_Port_dynamic_addresses = Logical_Switch_Port_dynamic_addresses{logical_switch_port: uuid, dynamic_address: string}
+typedef Logical_Switch_Port_external_ids = Logical_Switch_Port_external_ids{logical_switch_port: uuid, key: string, value: string}
+typedef Logical_Switch_Port_ips = Logical_Switch_Port_ips{logical_switch_port: uuid, mac: mac_addr_t, ip: ip_addr_t}
+typedef Logical_Switch_Port_macs = Logical_Switch_Port_macs{logical_switch_port: uuid, mac: mac_addr_t}
+typedef Logical_Switch_Port_options = Logical_Switch_Port_options{logical_switch_port: uuid, key: string, value: string}
+typedef Logical_Switch_Port_port_security = Logical_Switch_Port_port_security{logical_switch_port: uuid, port_security: string}
+typedef Logical_Switch_Port_ps_ips = Logical_Switch_Port_ps_ips{logical_switch_port: uuid, mac: mac_addr_t, ip: ip_subnet_t}
+typedef Logical_Switch_Port_ps_macs = Logical_Switch_Port_ps_macs{logical_switch_port: uuid, mac: mac_addr_t}
+typedef Logical_Switch_external_ids = Logical_Switch_external_ids{logical_switch: uuid, key: string, value: string}
+typedef Logical_Switch_has_stateful_acl_action = Logical_Switch_has_stateful_acl_action{logical_switch: uuid}
+typedef Logical_Switch_other_config = Logical_Switch_other_config{logical_switch: uuid, key: string, value: string}
+typedef NAT = NAT{id: uuid, logical_router: uuid, external_ip: string, external_mac: option_t<string>, logical_ip: string, logical_port: option_t<string>, type: option_t<string>}
+typedef NAT_external_ids = NAT_external_ids{nat: uuid, key: string, value: string}
+typedef NB_Global = NB_Global{nb_cfg: int, sb_cfg: int, hv_cfg: int}
+typedef NB_Global_external_ids = NB_Global_external_ids{key: string, value: string}
+typedef QoS = QoS{id: uuid, logical_switch: uuid, priority: int, direction: string, _match: string}
+typedef QoS_action = QoS_action{qos: uuid, key: string, value: int}
+typedef QoS_bandwidth = QoS_bandwidth{qos: uuid, key: string, value: int}
+typedef QoS_external_ids = QoS_external_ids{qos: uuid, key: string, value: string}
+typedef SSL = SSL{id: uuid, private_key: string, certificate: string, bootstrap_ca_cert: bool, ssl_protocols: string, ssl_ciphers: string}
+typedef SSL_external_ids = SSL_external_ids{ssl: uuid, key: string, value: string}
 typedef ip4_addr_t = bit<32>
 typedef ip4_subnet_t = IP4Subnet{addr: ip4_addr_t, mask: ip4_addr_t}
 typedef ip6_addr_t = bit<128>
@@ -31,263 +92,67 @@ function is_some (x: option_t<'A>): bool =
         Some{.value=_} -> true,
         _ -> false
     }
-ground relation ACL (
-    id: uuid,
-    name: option_t<string>,
-    logical_switch: uuid,
-    priority: int,
-    direction: string,
-    _match: string,
-    action: string,
-    log: bool,
-    severity: option_t<string>)
-ground relation ACL_external_ids (
-    acl: uuid,
-    key: string,
-    value: string)
-ground relation Address_Set (
-    id: uuid,
-    name: string)
-ground relation Address_Set_addresses (
-    address_set: uuid,
-    address: string)
-ground relation Address_Set_external_ids (
-    address_set: uuid,
-    key: string,
-    value: string)
-ground relation Connection (
-    id: uuid,
-    target: string,
-    is_connected: bool,
-    max_backoff: option_t<int>,
-    inactivity_probe: option_t<int>)
-ground relation Connection_external_ids (
-    connection: uuid,
-    value: string)
-ground relation Connection_other_config (
-    connection: uuid,
-    other_config: string)
-ground relation Connection_status (
-    connection: uuid,
-    key: string,
-    value: string)
-ground relation DHCP_Options (
-    id: uuid,
-    cidr: string)
-ground relation DHCP_Options_external_ids (
-    dhcp_options: uuid,
-    key: string,
-    value: string)
-relation DHCP_Options_netmask (
-    dhcp_options: uuid,
-    netmask: string)
-relation DHCP_Options_option_args (
-    dhcp_options: uuid,
-    option: string)
-ground relation DHCP_Options_options (
-    dhcp_options: uuid,
-    key: string,
-    value: string)
-relation DHCP_Options_server_ip (
-    dhcp_options: uuid,
-    server_ip: string)
-relation DHCP_Options_server_mac (
-    dhcp_options: uuid,
-    server_mac: mac_addr_t)
-relation DHCP_Options_stateful (
-    dhcp_options: uuid,
-    stateful: bool)
-ground relation DNS (
-    id: uuid,
-    logical_switch: uuid)
-ground relation DNS_external_ids (
-    dns: uuid,
-    key: string,
-    value: string)
-ground relation DNS_records (
-    dns: uuid,
-    key: string,
-    value: string)
-ground relation Gateway_Chassis (
-    id: uuid,
-    logical_router: uuid,
-    name: string,
-    chassis_name: string,
-    priority: int)
-ground relation Gateway_Chassis_external_ids (
-    gateway_chassis: uuid,
-    key: string,
-    value: string)
-ground relation Gateway_Chassis_options (
-    gateway_chassis: uuid,
-    key: string,
-    value: string)
-ground relation Load_Balancer (
-    id: uuid,
-    logical_switch: uuid,
-    protocol: option_t<string>,
-    name: string)
-ground relation Load_Balancer_external_ids (
-    load_balancer: uuid,
-    key: string,
-    value: string)
-relation Load_Balancer_ip_addresses (
-    load_balancer: uuid,
-    ip_address: string)
-ground relation Load_Balancer_vips (
-    load_balancer: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Router (
-    id: uuid,
-    enabled: option_t<bool>,
-    name: string)
-ground relation Logical_Router_Port (
-    id: uuid,
-    logical_router: uuid,
-    name: string,
-    mac: string,
-    peer: option_t<string>,
-    enabled: option_t<bool>)
-ground relation Logical_Router_Port_external_ids (
-    logical_router_port: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Router_Port_ipv6_ra_configs (
-    logical_router_port: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Router_Port_networks (
-    logical_router_port: uuid,
-    network: string)
-ground relation Logical_Router_Port_options (
-    logical_router_port: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Router_Static_Route (
-    id: uuid,
-    logical_router: uuid,
-    ip_prefix: string,
-    policy: option_t<string>,
-    nexthop: string,
-    output_port: option_t<string>)
-ground relation Logical_Router_Static_Route_external_ids (
-    logical_router_static_route: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Router_external_ids (
-    logical_router: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Router_options (
-    logical_router: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Switch (
-    id: uuid,
-    name: string,
-    type: string)
-ground relation Logical_Switch_Port (
-    id: uuid,
-    logical_switch: uuid,
-    parent: option_t<string>,
-    tag_request: option_t<int>,
-    tag: option_t<int>,
-    up: option_t<bool>,
-    enabled: option_t<bool>,
-    dhcpv4_options: option_t<uuid>,
-    dhcpv6_options: option_t<uuid>,
-    name: string,
-    type: string)
-ground relation Logical_Switch_Port_addresses (
-    logical_switch_port: uuid,
-    address: string)
-ground relation Logical_Switch_Port_dynamic_addresses (
-    logical_switch_port: uuid,
-    dynamic_address: string)
-ground relation Logical_Switch_Port_external_ids (
-    logical_switch_port: uuid,
-    key: string,
-    value: string)
-relation Logical_Switch_Port_ips (
-    logical_switch_port: uuid,
-    mac: mac_addr_t,
-    ip: ip_addr_t)
-relation Logical_Switch_Port_macs (
-    logical_switch_port: uuid,
-    mac: mac_addr_t)
-ground relation Logical_Switch_Port_options (
-    logical_switch_port: uuid,
-    key: string,
-    value: string)
-ground relation Logical_Switch_Port_port_security (
-    logical_switch_port: uuid,
-    port_security: string)
-relation Logical_Switch_Port_ps_ips (
-    logical_switch_port: uuid,
-    mac: mac_addr_t,
-    ip: ip_subnet_t)
-relation Logical_Switch_Port_ps_macs (
-    logical_switch_port: uuid,
-    mac: mac_addr_t)
-ground relation Logical_Switch_external_ids (
-    logical_switch: uuid,
-    key: string,
-    value: string)
-relation Logical_Switch_has_stateful_acl_action (
-    logical_switch: uuid)
-ground relation Logical_Switch_other_config (
-    logical_switch: uuid,
-    key: string,
-    value: string)
-ground relation NAT (
-    id: uuid,
-    logical_router: uuid,
-    external_ip: string,
-    external_mac: option_t<string>,
-    logical_ip: string,
-    logical_port: option_t<string>,
-    type: option_t<string>)
-ground relation NAT_external_ids (
-    nat: uuid,
-    key: string,
-    value: string)
-ground relation NB_Global (
-    nb_cfg: int,
-    sb_cfg: int,
-    hv_cfg: int)
-ground relation NB_Global_external_ids (
-    key: string,
-    value: string)
-ground relation QoS (
-    id: uuid,
-    logical_switch: uuid,
-    priority: int,
-    direction: string,
-    _match: string)
-ground relation QoS_action (
-    qos: uuid,
-    key: string,
-    value: int)
-ground relation QoS_bandwidth (
-    qos: uuid,
-    key: string,
-    value: int)
-ground relation QoS_external_ids (
-    qos: uuid,
-    key: string,
-    value: string)
-ground relation SSL (
-    id: uuid,
-    private_key: string,
-    certificate: string,
-    bootstrap_ca_cert: bool,
-    ssl_protocols: string,
-    ssl_ciphers: string)
-ground relation SSL_external_ids (
-    ssl: uuid,
-    key: string,
-    value: string)
+ground relation ACL (ACL)
+ground relation ACL_external_ids (ACL_external_ids)
+ground relation Address_Set (Address_Set)
+ground relation Address_Set_addresses (Address_Set_addresses)
+ground relation Address_Set_external_ids (Address_Set_external_ids)
+ground relation Connection (Connection)
+ground relation Connection_external_ids (Connection_external_ids)
+ground relation Connection_other_config (Connection_other_config)
+ground relation Connection_status (Connection_status)
+ground relation DHCP_Options (DHCP_Options)
+ground relation DHCP_Options_external_ids (DHCP_Options_external_ids)
+relation DHCP_Options_netmask (DHCP_Options_netmask)
+relation DHCP_Options_option_args (DHCP_Options_option_args)
+ground relation DHCP_Options_options (DHCP_Options_options)
+relation DHCP_Options_server_ip (DHCP_Options_server_ip)
+relation DHCP_Options_server_mac (DHCP_Options_server_mac)
+relation DHCP_Options_stateful (DHCP_Options_stateful)
+ground relation DNS (DNS)
+ground relation DNS_external_ids (DNS_external_ids)
+ground relation DNS_records (DNS_records)
+ground relation Gateway_Chassis (Gateway_Chassis)
+ground relation Gateway_Chassis_external_ids (Gateway_Chassis_external_ids)
+ground relation Gateway_Chassis_options (Gateway_Chassis_options)
+ground relation Load_Balancer (Load_Balancer)
+ground relation Load_Balancer_external_ids (Load_Balancer_external_ids)
+relation Load_Balancer_ip_addresses (Load_Balancer_ip_addresses)
+ground relation Load_Balancer_vips (Load_Balancer_vips)
+ground relation Logical_Router (Logical_Router)
+ground relation Logical_Router_Port (Logical_Router_Port)
+ground relation Logical_Router_Port_external_ids (Logical_Router_Port_external_ids)
+ground relation Logical_Router_Port_ipv6_ra_configs (Logical_Router_Port_ipv6_ra_configs)
+ground relation Logical_Router_Port_networks (Logical_Router_Port_networks)
+ground relation Logical_Router_Port_options (Logical_Router_Port_options)
+ground relation Logical_Router_Static_Route (Logical_Router_Static_Route)
+ground relation Logical_Router_Static_Route_external_ids (Logical_Router_Static_Route_external_ids)
+ground relation Logical_Router_external_ids (Logical_Router_external_ids)
+ground relation Logical_Router_options (Logical_Router_options)
+ground relation Logical_Switch (Logical_Switch)
+ground relation Logical_Switch_Port (Logical_Switch_Port)
+ground relation Logical_Switch_Port_addresses (Logical_Switch_Port_addresses)
+ground relation Logical_Switch_Port_dynamic_addresses (Logical_Switch_Port_dynamic_addresses)
+ground relation Logical_Switch_Port_external_ids (Logical_Switch_Port_external_ids)
+relation Logical_Switch_Port_ips (Logical_Switch_Port_ips)
+relation Logical_Switch_Port_macs (Logical_Switch_Port_macs)
+ground relation Logical_Switch_Port_options (Logical_Switch_Port_options)
+ground relation Logical_Switch_Port_port_security (Logical_Switch_Port_port_security)
+relation Logical_Switch_Port_ps_ips (Logical_Switch_Port_ps_ips)
+relation Logical_Switch_Port_ps_macs (Logical_Switch_Port_ps_macs)
+ground relation Logical_Switch_external_ids (Logical_Switch_external_ids)
+relation Logical_Switch_has_stateful_acl_action (Logical_Switch_has_stateful_acl_action)
+ground relation Logical_Switch_other_config (Logical_Switch_other_config)
+ground relation NAT (NAT)
+ground relation NAT_external_ids (NAT_external_ids)
+ground relation NB_Global (NB_Global)
+ground relation NB_Global_external_ids (NB_Global_external_ids)
+ground relation QoS (QoS)
+ground relation QoS_action (QoS_action)
+ground relation QoS_bandwidth (QoS_bandwidth)
+ground relation QoS_external_ids (QoS_external_ids)
+ground relation SSL (SSL)
+ground relation SSL_external_ids (SSL_external_ids)
 Load_Balancer_ip_addresses(.load_balancer=lb, .ip_address=ip_address_and_port_from_lb_key(key).ip) :- Load_Balancer_vips(.load_balancer=lb, .key=key, .value=_).
 Logical_Switch_Port_ips(.logical_switch_port=lsp, .mac=mac, .ip=ip) :- Logical_Switch_Port_addresses(.logical_switch_port=lsp, .address=addrs), (var mac, var ips) = extract_mac(addrs), FlatMap(ip = extract_ips(ips)).
 Logical_Switch_Port_ips(.logical_switch_port=lsp, .mac=mac, .ip=ip) :- Logical_Switch_Port_dynamic_addresses(.logical_switch_port=lsp, .dynamic_address=addrs), (var mac, var ips) = extract_mac(addrs), FlatMap(ip = extract_ips(ips)).

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -92,67 +92,67 @@ function is_some (x: option_t<'A>): bool =
         Some{.value=_} -> true,
         _ -> false
     }
-ground relation ACL : ACL
-ground relation ACL_external_ids : ACL_external_ids
-ground relation Address_Set : Address_Set
-ground relation Address_Set_addresses : Address_Set_addresses
-ground relation Address_Set_external_ids : Address_Set_external_ids
-ground relation Connection : Connection
-ground relation Connection_external_ids : Connection_external_ids
-ground relation Connection_other_config : Connection_other_config
-ground relation Connection_status : Connection_status
-ground relation DHCP_Options : DHCP_Options
-ground relation DHCP_Options_external_ids : DHCP_Options_external_ids
-relation DHCP_Options_netmask : DHCP_Options_netmask
-relation DHCP_Options_option_args : DHCP_Options_option_args
-ground relation DHCP_Options_options : DHCP_Options_options
-relation DHCP_Options_server_ip : DHCP_Options_server_ip
-relation DHCP_Options_server_mac : DHCP_Options_server_mac
-relation DHCP_Options_stateful : DHCP_Options_stateful
-ground relation DNS : DNS
-ground relation DNS_external_ids : DNS_external_ids
-ground relation DNS_records : DNS_records
-ground relation Gateway_Chassis : Gateway_Chassis
-ground relation Gateway_Chassis_external_ids : Gateway_Chassis_external_ids
-ground relation Gateway_Chassis_options : Gateway_Chassis_options
-ground relation Load_Balancer : Load_Balancer
-ground relation Load_Balancer_external_ids : Load_Balancer_external_ids
-relation Load_Balancer_ip_addresses : Load_Balancer_ip_addresses
-ground relation Load_Balancer_vips : Load_Balancer_vips
-ground relation Logical_Router : Logical_Router
-ground relation Logical_Router_Port : Logical_Router_Port
-ground relation Logical_Router_Port_external_ids : Logical_Router_Port_external_ids
-ground relation Logical_Router_Port_ipv6_ra_configs : Logical_Router_Port_ipv6_ra_configs
-ground relation Logical_Router_Port_networks : Logical_Router_Port_networks
-ground relation Logical_Router_Port_options : Logical_Router_Port_options
-ground relation Logical_Router_Static_Route : Logical_Router_Static_Route
-ground relation Logical_Router_Static_Route_external_ids : Logical_Router_Static_Route_external_ids
-ground relation Logical_Router_external_ids : Logical_Router_external_ids
-ground relation Logical_Router_options : Logical_Router_options
-ground relation Logical_Switch : Logical_Switch
-ground relation Logical_Switch_Port : Logical_Switch_Port
-ground relation Logical_Switch_Port_addresses : Logical_Switch_Port_addresses
-ground relation Logical_Switch_Port_dynamic_addresses : Logical_Switch_Port_dynamic_addresses
-ground relation Logical_Switch_Port_external_ids : Logical_Switch_Port_external_ids
-relation Logical_Switch_Port_ips : Logical_Switch_Port_ips
-relation Logical_Switch_Port_macs : Logical_Switch_Port_macs
-ground relation Logical_Switch_Port_options : Logical_Switch_Port_options
-ground relation Logical_Switch_Port_port_security : Logical_Switch_Port_port_security
-relation Logical_Switch_Port_ps_ips : Logical_Switch_Port_ps_ips
-relation Logical_Switch_Port_ps_macs : Logical_Switch_Port_ps_macs
-ground relation Logical_Switch_external_ids : Logical_Switch_external_ids
-relation Logical_Switch_has_stateful_acl_action : Logical_Switch_has_stateful_acl_action
-ground relation Logical_Switch_other_config : Logical_Switch_other_config
-ground relation NAT : NAT
-ground relation NAT_external_ids : NAT_external_ids
-ground relation NB_Global : NB_Global
-ground relation NB_Global_external_ids : NB_Global_external_ids
-ground relation QoS : QoS
-ground relation QoS_action : QoS_action
-ground relation QoS_bandwidth : QoS_bandwidth
-ground relation QoS_external_ids : QoS_external_ids
-ground relation SSL : SSL
-ground relation SSL_external_ids : SSL_external_ids
+ground relation ACL [ACL]
+ground relation ACL_external_ids [ACL_external_ids]
+ground relation Address_Set [Address_Set]
+ground relation Address_Set_addresses [Address_Set_addresses]
+ground relation Address_Set_external_ids [Address_Set_external_ids]
+ground relation Connection [Connection]
+ground relation Connection_external_ids [Connection_external_ids]
+ground relation Connection_other_config [Connection_other_config]
+ground relation Connection_status [Connection_status]
+ground relation DHCP_Options [DHCP_Options]
+ground relation DHCP_Options_external_ids [DHCP_Options_external_ids]
+relation DHCP_Options_netmask [DHCP_Options_netmask]
+relation DHCP_Options_option_args [DHCP_Options_option_args]
+ground relation DHCP_Options_options [DHCP_Options_options]
+relation DHCP_Options_server_ip [DHCP_Options_server_ip]
+relation DHCP_Options_server_mac [DHCP_Options_server_mac]
+relation DHCP_Options_stateful [DHCP_Options_stateful]
+ground relation DNS [DNS]
+ground relation DNS_external_ids [DNS_external_ids]
+ground relation DNS_records [DNS_records]
+ground relation Gateway_Chassis [Gateway_Chassis]
+ground relation Gateway_Chassis_external_ids [Gateway_Chassis_external_ids]
+ground relation Gateway_Chassis_options [Gateway_Chassis_options]
+ground relation Load_Balancer [Load_Balancer]
+ground relation Load_Balancer_external_ids [Load_Balancer_external_ids]
+relation Load_Balancer_ip_addresses [Load_Balancer_ip_addresses]
+ground relation Load_Balancer_vips [Load_Balancer_vips]
+ground relation Logical_Router [Logical_Router]
+ground relation Logical_Router_Port [Logical_Router_Port]
+ground relation Logical_Router_Port_external_ids [Logical_Router_Port_external_ids]
+ground relation Logical_Router_Port_ipv6_ra_configs [Logical_Router_Port_ipv6_ra_configs]
+ground relation Logical_Router_Port_networks [Logical_Router_Port_networks]
+ground relation Logical_Router_Port_options [Logical_Router_Port_options]
+ground relation Logical_Router_Static_Route [Logical_Router_Static_Route]
+ground relation Logical_Router_Static_Route_external_ids [Logical_Router_Static_Route_external_ids]
+ground relation Logical_Router_external_ids [Logical_Router_external_ids]
+ground relation Logical_Router_options [Logical_Router_options]
+ground relation Logical_Switch [Logical_Switch]
+ground relation Logical_Switch_Port [Logical_Switch_Port]
+ground relation Logical_Switch_Port_addresses [Logical_Switch_Port_addresses]
+ground relation Logical_Switch_Port_dynamic_addresses [Logical_Switch_Port_dynamic_addresses]
+ground relation Logical_Switch_Port_external_ids [Logical_Switch_Port_external_ids]
+relation Logical_Switch_Port_ips [Logical_Switch_Port_ips]
+relation Logical_Switch_Port_macs [Logical_Switch_Port_macs]
+ground relation Logical_Switch_Port_options [Logical_Switch_Port_options]
+ground relation Logical_Switch_Port_port_security [Logical_Switch_Port_port_security]
+relation Logical_Switch_Port_ps_ips [Logical_Switch_Port_ps_ips]
+relation Logical_Switch_Port_ps_macs [Logical_Switch_Port_ps_macs]
+ground relation Logical_Switch_external_ids [Logical_Switch_external_ids]
+relation Logical_Switch_has_stateful_acl_action [Logical_Switch_has_stateful_acl_action]
+ground relation Logical_Switch_other_config [Logical_Switch_other_config]
+ground relation NAT [NAT]
+ground relation NAT_external_ids [NAT_external_ids]
+ground relation NB_Global [NB_Global]
+ground relation NB_Global_external_ids [NB_Global_external_ids]
+ground relation QoS [QoS]
+ground relation QoS_action [QoS_action]
+ground relation QoS_bandwidth [QoS_bandwidth]
+ground relation QoS_external_ids [QoS_external_ids]
+ground relation SSL [SSL]
+ground relation SSL_external_ids [SSL_external_ids]
 Load_Balancer_ip_addresses(.load_balancer=lb, .ip_address=ip_address_and_port_from_lb_key(key).ip) :- Load_Balancer_vips(.load_balancer=lb, .key=key, .value=_).
 Logical_Switch_Port_ips(.logical_switch_port=lsp, .mac=mac, .ip=ip) :- Logical_Switch_Port_addresses(.logical_switch_port=lsp, .address=addrs), (var mac, var ips) = extract_mac(addrs), FlatMap(ip = extract_ips(ips)).
 Logical_Switch_Port_ips(.logical_switch_port=lsp, .mac=mac, .ip=ip) :- Logical_Switch_Port_dynamic_addresses(.logical_switch_port=lsp, .dynamic_address=addrs), (var mac, var ips) = extract_mac(addrs), FlatMap(ip = extract_ips(ips)).

--- a/test/datalog_tests/rules.ast.expected
+++ b/test/datalog_tests/rules.ast.expected
@@ -3,12 +3,12 @@ typedef R3 = R3{f1: int, f2: bool}
 typedef R6 = R6{f: int}
 typedef set<'A>
 function __builtin_2string (x: 'X): string
-ground relation R1 : R1
-ground relation R2 : (int, int)
-ground relation R3 : R3
-relation R4 : R3
-relation R5 : int
-relation R6 : R6
+ground relation R1 [R1]
+ground relation R2 [(int, int)]
+ground relation R3 [R3]
+relation R4 [R3]
+relation R5 [int]
+relation R6 [R6]
 R1[1].
 R2[(1, 2)].
 R4[x] :- R3[x].

--- a/test/datalog_tests/rules.ast.expected
+++ b/test/datalog_tests/rules.ast.expected
@@ -1,0 +1,16 @@
+typedef R1 = int
+typedef R3 = R3{f1: int, f2: bool}
+typedef R6 = R6{f: int}
+typedef set<'A>
+function __builtin_2string (x: 'X): string
+ground relation R1 : R1
+ground relation R2 : (int, int)
+ground relation R3 : R3
+relation R4 : R3
+relation R5 : int
+relation R6 : R6
+R1[1].
+R2[(1, 2)].
+R4[x] :- R3[x].
+R5[x.f1] :- R3[x].
+R6(.f=x.f1) :- R3[x].

--- a/test/datalog_tests/rules.ast.expected
+++ b/test/datalog_tests/rules.ast.expected
@@ -1,6 +1,11 @@
 typedef R1 = int
 typedef R3 = R3{f1: int, f2: bool}
 typedef R6 = R6{f: int}
+typedef R7 = R7{f1: int, f2: bit<16>} | R7Other{}
+typedef T = T{x: int, y: string}
+typedef X = X{b: int, c: R3, d: R1}
+typedef Y = Y{b: int, e: string}
+typedef Z = Z{x: int, y: R3}
 typedef set<'A>
 function __builtin_2string (x: 'X): string
 ground relation R1 [R1]
@@ -9,8 +14,18 @@ ground relation R3 [R3]
 relation R4 [R3]
 relation R5 [int]
 relation R6 [R6]
+relation R7 [R7]
+relation T [T]
+ground relation X [X]
+ground relation Y [Y]
+relation Z [Z]
 R1[1].
 R2[(1, 2)].
 R4[x] :- R3[x].
 R5[x.f1] :- R3[x].
 R6(.f=x.f1) :- R3[x].
+Z(.x=a.b, .y=a.c) :- X[a].
+T(.x=a.b, .y=e) :- X[a], Y(.b=a.d, .e=e).
+R7(.f1=1, .f2=2).
+R7(.f1=1, .f2=3).
+R7[R7Other{}].

--- a/test/datalog_tests/rules.dl
+++ b/test/datalog_tests/rules.dl
@@ -1,14 +1,14 @@
 typedef R1 = int
 
-ground relation R1:R1
-ground relation R2:(int, int)
+ground relation R1[R1]
+ground relation R2[(int, int)]
 
 R1[1].
 R2[(1,2)].
 
 ground relation R3(f1: int, f2: bool)
-relation R4:R3
-relation R5:int
+relation R4[R3]
+relation R5[int]
 relation R6(f: int)
 
 R4[x] :- R3[x].

--- a/test/datalog_tests/rules.dl
+++ b/test/datalog_tests/rules.dl
@@ -1,0 +1,16 @@
+typedef R1 = int
+
+ground relation R1:R1
+ground relation R2:(int, int)
+
+R1[1].
+R2[(1,2)].
+
+ground relation R3(f1: int, f2: bool)
+relation R4:R3
+relation R5:int
+relation R6(f: int)
+
+R4[x] :- R3[x].
+R5[x.f1] :- R3[x].
+R6(x.f1) :- R3[x].

--- a/test/datalog_tests/rules.dl
+++ b/test/datalog_tests/rules.dl
@@ -14,3 +14,21 @@ relation R6(f: int)
 R4[x] :- R3[x].
 R5[x.f1] :- R3[x].
 R6(x.f1) :- R3[x].
+
+ground relation X(b: int, c: R3, d: R1)
+relation Z(x: int, y: R3)
+Z(a.b, a.c) :- X[a].
+
+ground relation Y(b: int, e: string)
+relation T(x: int, y: string)
+
+T(a.b, e) :- X[a], Y(a.d, e).
+
+typedef R7 = R7{f1: int, f2: bit<16>}
+           | R7Other
+
+relation R7[R7]
+
+R7(1,2).
+R7[R7{1,3}].
+R7[R7Other].

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -1,3 +1,9 @@
-error: ./test/datalog_tests/rules.fail.dl:10:1-11:1: At most one relation in the right-hand side of a rule can be mutually recursive with its head. The following RHS literals are mutually recursive with R2: R3(.a3=x, .b3=y), R4(.a4=y, .b4=z)
+error: ./test/datalog_tests/rules.fail.dl:5:3-5:6: Unknown constructor: R1
+
+./test/datalog_tests/rules.fail.dl:5:1-7:1: Multiple definitions of type R1 at the following locations:
+  ./test/datalog_tests/rules.fail.dl:5:1-7:1
+  ./test/datalog_tests/rules.fail.dl:7:1-9:1
+
+error: ./test/datalog_tests/rules.fail.dl:12:1-13:1: At most one relation in the right-hand side of a rule can be mutually recursive with its head. The following RHS literals are mutually recursive with R2: R3(.a3=x, .b3=y), R4(.a4=y, .b4=z)
 
 error: ./test/datalog_tests/rules.fail.dl:10:1-11:1: Relation R3 is mutually recursive with R2 and therefore cannot appear negated in this rule

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -1,4 +1,6 @@
-error: ./test/datalog_tests/rules.fail.dl:5:3-5:6: Unknown constructor: R1
+Failed to parse input file: "./test/datalog_tests/rules.fail.dl" (line 3, column 19):
+unexpected ":"
+expecting letter or digit, "_", "(" or "["
 
 ./test/datalog_tests/rules.fail.dl:5:1-7:1: Multiple definitions of type R1 at the following locations:
   ./test/datalog_tests/rules.fail.dl:5:1-7:1

--- a/test/datalog_tests/rules.fail.dl
+++ b/test/datalog_tests/rules.fail.dl
@@ -1,3 +1,19 @@
+// cannot use parenthes if type name does not match relation name
+
+ground relation R1: int
+
+R1(1).
+
+//---
+
+// relation name collides with existing type name
+
+typedef R1 = int
+
+ground relation R1(a1: string)
+
+//---
+
 // non-linear rules
 
 ground relation R1(a1: string)

--- a/test/datalog_tests/statements.ast.expected
+++ b/test/datalog_tests/statements.ast.expected
@@ -3,9 +3,9 @@ typedef X = X{field: int}
 typedef Z = Z{field: int}
 typedef set<'A>
 function __builtin_2string (x: 'X): string
-relation W : W
-ground relation X : X
-relation Z : Z
+relation W [W]
+ground relation X [X]
+relation Z [Z]
 Z(.field=a) :- X(.field=a).
 Z(.field=a) :- X(.field=a), match (a) {
                                 1 -> true,

--- a/test/datalog_tests/statements.ast.expected
+++ b/test/datalog_tests/statements.ast.expected
@@ -1,13 +1,11 @@
+typedef W = W{f1: int, f2: int, f3: int}
+typedef X = X{field: int}
+typedef Z = Z{field: int}
 typedef set<'A>
 function __builtin_2string (x: 'X): string
-relation W (
-    f1: int,
-    f2: int,
-    f3: int)
-ground relation X (
-    field: int)
-relation Z (
-    field: int)
+relation W (W)
+ground relation X (X)
+relation Z (Z)
 Z(.field=a) :- X(.field=a).
 Z(.field=a) :- X(.field=a), match (a) {
                                 1 -> true,
@@ -38,13 +36,13 @@ W(.f1=a, .f2=b, .f3=c) :- X(.field=a), var b = (a + 2), var c = (b + a).
 for (a in X)
     skip
 for (a in X)
-    Z ( a )
+    Z(a)
 for (a in X)
     match (a)
     {
-        1 -> Z ( a ),
-        2 -> Z ( (a + 1) ),
-        _ -> Z ( (a - 1) )
+        1 -> Z(a),
+        2 -> Z((a + 1)),
+        _ -> Z((a - 1))
     }
 for (a in X if true)
     skip
@@ -57,10 +55,10 @@ for (a in X)
         skip
     }
 for (a in X if ((a % 2) == 0))
-    Z ( a )
+    Z(a)
 for (a in X)
     if (((a % 2) == 0))
-        Z ( a )
+        Z(a)
 for (a in X)
     {
         if ((a == 2))
@@ -76,30 +74,30 @@ for (a in X)
 for (a in X)
     {
         if ((a == 2))
-            Z ( (a + 1) )
+            Z((a + 1))
         else
-            Z ( a )
+            Z(a)
     }
 for (a in X)
     if ((a >= 2))
         if ((a > 2))
             {
-                Z ( a );
-                Z ( (a + 2) )
+                Z(a);
+                Z((a + 2))
             }
 for (a in X)
     {
         for (b in X)
-            Z ( (a + b) );
+            Z((a + b));
         for (c in X)
-            Z ( (a + c) )
+            Z((a + c))
     }
 for (a in X)
     let b = (a + 2) in
         skip
 for (a in X)
     let b = (a + 2) in
-        Z ( (a + b) )
+        Z((a + b))
 for (a in X)
     let b = (a + 2), c = (b + a) in
-        W ( a, b, c )
+        W(a, b, c)

--- a/test/datalog_tests/statements.ast.expected
+++ b/test/datalog_tests/statements.ast.expected
@@ -3,9 +3,9 @@ typedef X = X{field: int}
 typedef Z = Z{field: int}
 typedef set<'A>
 function __builtin_2string (x: 'X): string
-relation W (W)
-ground relation X (X)
-relation Z (Z)
+relation W : W
+ground relation X : X
+relation Z : Z
 Z(.field=a) :- X(.field=a).
 Z(.field=a) :- X(.field=a), match (a) {
                                 1 -> true,

--- a/test/datalog_tests/strings.ast.expected
+++ b/test/datalog_tests/strings.ast.expected
@@ -39,7 +39,7 @@ function tostring2 (): () =
         ((var e: serializable_t) = ConsInt{.x=0};
          (var err = (((((((((("a=" ++ __builtin_2string(a)) ++ ", b=") ++ __builtin_2string(b)) ++ ", c=") ++ __builtin_2string(c)) ++ ", d=") ++ d) ++ ", e:") ++ serializable_t2string(e)) ++ "");
           ()))))))
-ground relation Strings : Strings
+ground relation Strings [Strings]
 Strings(.s="").
 Strings(.s="foo").
 Strings(.s="bar\n").

--- a/test/datalog_tests/strings.ast.expected
+++ b/test/datalog_tests/strings.ast.expected
@@ -1,3 +1,4 @@
+typedef Strings = Strings{s: string}
 typedef serializable_t = ConsInt{x: int} | ConsBit{y: bit<32>} | ConsBool{z: bool} | Cons0{}
 typedef set<'A>
 function __builtin_2string (x: 'X): string
@@ -38,8 +39,7 @@ function tostring2 (): () =
         ((var e: serializable_t) = ConsInt{.x=0};
          (var err = (((((((((("a=" ++ __builtin_2string(a)) ++ ", b=") ++ __builtin_2string(b)) ++ ", c=") ++ __builtin_2string(c)) ++ ", d=") ++ d) ++ ", e:") ++ serializable_t2string(e)) ++ "");
           ()))))))
-ground relation Strings (
-    s: string)
+ground relation Strings (Strings)
 Strings(.s="").
 Strings(.s="foo").
 Strings(.s="bar\n").

--- a/test/datalog_tests/strings.ast.expected
+++ b/test/datalog_tests/strings.ast.expected
@@ -39,7 +39,7 @@ function tostring2 (): () =
         ((var e: serializable_t) = ConsInt{.x=0};
          (var err = (((((((((("a=" ++ __builtin_2string(a)) ++ ", b=") ++ __builtin_2string(b)) ++ ", c=") ++ __builtin_2string(c)) ++ ", d=") ++ d) ++ ", e:") ++ serializable_t2string(e)) ++ "");
           ()))))))
-ground relation Strings (Strings)
+ground relation Strings : Strings
 Strings(.s="").
 Strings(.s="foo").
 Strings(.s="bar\n").


### PR DESCRIPTION
Elements of relations now have types. The old relation declaration syntax now works as syntactic sugar that creates a new type and a relation whose elements belong to this type. The type has the same name as the relation and has a single type constructor with the same name. 

```
relation R(f1: int, f2: bool)
```
is equivalent to:
```
typedef R = R{f1: int, f2:bool}
relation R[R]
```
where the second form is the new, more general, declaration syntax. Relations can have arbitrary types, not just structs, e.g.,

```
relation R2[(int, int)]
```

There is also new syntax for atoms:
```
atom ::= rel_name "(" expr (,expr)* ")"
       | rel_name "(" "." arg_name "=" expr [("," "." arg_name "=" expr)*] ")"
       | rel_name "[" expr "]"
```

The first two forms are the same as before. The third one is new and more general, e.g., atom

```
Rel(val1, val2)
```
expands to
```
Rel[Rel1(val1, val2)]
```