### PR TITLE
Change test script to run on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Instructions for writing and testing your own Datalog programs are [here](doc/te
 # Installing from sources
 
 ## Prerequisites
-We have only tested our software on Ubuntu Linux.
+We have tested our software on Ubuntu Linux and MacOS.
 
 The compilers are written in Haskell.  One needs the Glasgow Haskell
 Compiler.  The Haskell compiler is managed by the

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -256,8 +256,8 @@ ffiTest fname specname rust_dir = do
         hClose hdat
         -- Run C program
         hout <- openFile dumpfile WriteMode
-        code <- withCreateProcess (proc ("./" ++ exefile) []){
-                            cwd = Just $ joinPath [rust_dir, specname],
+        cwd <- makeAbsolute $ joinPath [rust_dir, specname]
+        code <- withCreateProcess (proc (cwd </> exefile) []){
                             std_out = UseHandle hout,
                             env = Just [("LD_LIBRARY_PATH", "target/" ++ bUILD_TYPE)]} $
             \_ _ _ phandle -> waitForProcess phandle


### PR DESCRIPTION
When using `cwd` in `withCreateProcess`, absolute paths should be used to ensure portability. See doc for [`cmdspec :: CmdSpec`](http://hackage.haskell.org/package/process-1.6.4.0/docs/System-Process.html). See also haskell/process#87