### PR TITLE
Ref<T> type and convenience syntax around it

### DIFF
--- a/lib/std.dl
+++ b/lib/std.dl
@@ -1,6 +1,13 @@
 /* Description: DDlog "standard library" automatically imported into every module */
 
 /*
+ * Ref
+ */
+extern type Ref<'A>
+
+extern function ref_new(x: 'A): Ref<'A>
+
+/*
  * Option
  */
 

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -35,6 +35,11 @@ typedef Either<'A,'B> = Left{l: 'A}
                       | Right{r: 'B}
 
 /*
+ * Range
+ */
+extern function range(from: 'A, to: 'A, step: 'A): Vec<'A>
+
+/*
  * String conversion
  */
 extern function __builtin_2string(x: 'X): string

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -48,6 +48,7 @@ extern function hex(x: 'X): string
 extern function parse_dec_u64(s: string): Option<bit<64>>
 
 extern function string_join(strings: Vec<string>, sep: string): string
+extern function string_split(s: string, sep: string): Vec<string>
 
 extern function str_to_lower(s: string): string
 

--- a/lib/std.rs
+++ b/lib/std.rs
@@ -18,6 +18,14 @@ use std::iter::FromIterator;
 const XX_SEED1: u64 = 0x23b691a751d0e108;
 const XX_SEED2: u64 = 0x20b09801dce5ff84;
 
+// Ref
+pub type std_Ref<A> = arcval::ArcVal<A>;
+
+pub fn std_ref_new<A: Clone>(x: &A) -> std_Ref<A> {
+    arcval::ArcVal::from(x.clone())
+}
+
+
 // Option
 fn option2std<T: Clone>(x: Option<T>) -> std_Option<T> {
     match x {

--- a/lib/std.rs
+++ b/lib/std.rs
@@ -41,7 +41,7 @@ pub fn std_range<A: Clone + Ord + ops::Add<Output = A> + PartialOrd>(from: &A, t
     let mut x = from.clone();
     while x <= *to {
         vec.push(x.clone());
-        x = x + to.clone();
+        x = x + step.clone();
     };
     vec
 }

--- a/lib/std.rs
+++ b/lib/std.rs
@@ -375,6 +375,10 @@ pub fn std_string_join(strings: &std_Vec<arcval::DDString>, sep: &arcval::DDStri
     arcval::DDString::from(strings.x.iter().map(|s|s.str()).collect::<Vec<&str>>().join(sep.as_str()))
 }
 
+pub fn std_string_split(s: &arcval::DDString, sep: &arcval::DDString) -> std_Vec<arcval::DDString> {
+    std_Vec{x: s.str().split(sep.str()).map(|x| arcval::DDString::from_str(x)).collect()}
+}
+
 pub fn std_str_to_lower(s: &arcval::DDString) -> arcval::DDString {
     arcval::DDString::from(s.str().to_lowercase())
 }

--- a/lib/std.rs
+++ b/lib/std.rs
@@ -14,6 +14,7 @@ use std::collections::btree_map;
 use std::vec::{Vec};
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FromIterator;
+use std::ops;
 
 const XX_SEED1: u64 = 0x23b691a751d0e108;
 const XX_SEED2: u64 = 0x20b09801dce5ff84;
@@ -32,6 +33,17 @@ fn option2std<T: Clone>(x: Option<T>) -> std_Option<T> {
         None => std_Option::std_None,
         Some(v) => std_Option::std_Some{x: v}
     }
+}
+
+// Range
+pub fn std_range<A: Clone + Ord + ops::Add<Output = A> + PartialOrd>(from: &A, to: &A, step: &A) -> std_Vec<A> {
+    let mut vec = std_Vec::new();
+    let mut x = from.clone();
+    while x <= *to {
+        vec.push(x.clone());
+        x = x + to.clone();
+    };
+    vec
 }
 
 // Vector

--- a/rust/template/differential_datalog/arcval.rs
+++ b/rust/template/differential_datalog/arcval.rs
@@ -10,15 +10,15 @@ use super::record::{FromRecord, IntoRecord, Record};
 
 
 #[derive(Eq, PartialOrd, PartialEq, Ord, Clone, Hash)]
-pub struct ArcVal<T: Val>{x: Arc<T>}
+pub struct ArcVal<T>{x: Arc<T>}
 
-impl<T: Val+Default> Default for ArcVal<T> {
+impl<T: Default> Default for ArcVal<T> {
     fn default() -> Self {
         Self{x: Arc::new(T::default())}
     }
 }
 
-impl<T: Val> Deref for ArcVal<T> {
+impl<T> Deref for ArcVal<T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -26,13 +26,13 @@ impl<T: Val> Deref for ArcVal<T> {
     }
 }
 
-impl<T:Val> From<T> for ArcVal<T> {
+impl<T> From<T> for ArcVal<T> {
     fn from(x: T) -> Self {
         Self{x: Arc::new(x)}
     }
 }
 
-impl<T:Val> Abomonation for ArcVal<T> {
+impl<T:Abomonation> Abomonation for ArcVal<T> {
     unsafe fn entomb<W: io::Write>(&self, write: &mut W) -> io::Result<()> {
         self.deref().entomb(write)
     }
@@ -66,19 +66,19 @@ impl ArcVal<String> {
 }
 
 
-impl<T: Val> fmt::Display for ArcVal<T> {
+impl<T: fmt::Display> fmt::Display for ArcVal<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.deref().fmt(f)
     }
 }
 
-impl<T: Val> fmt::Debug for ArcVal<T> {
+impl<T: fmt::Debug> fmt::Debug for ArcVal<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.deref().fmt(f)
     }
 }
 
-impl<T: Val> Serialize for ArcVal<T> {
+impl<T: Serialize> Serialize for ArcVal<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
@@ -86,7 +86,7 @@ impl<T: Val> Serialize for ArcVal<T> {
     }
 }
 
-impl<'de, T: Val> Deserialize<'de> for ArcVal<T> {
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for ArcVal<T> {
     fn deserialize<D>(deserializer: D) -> Result<ArcVal<T>, D::Error>
         where D: Deserializer<'de>
     {
@@ -94,13 +94,13 @@ impl<'de, T: Val> Deserialize<'de> for ArcVal<T> {
     }
 }
 
-impl<T: Val+FromRecord> FromRecord for ArcVal<T> {
+impl<T: FromRecord> FromRecord for ArcVal<T> {
     fn from_record(val: &Record) -> Result<Self, String> {
         T::from_record(val).map(|x|Self::from(x))
     }
 }
 
-impl<T: Val+IntoRecord> IntoRecord for ArcVal<T> {
+impl<T: IntoRecord+Clone> IntoRecord for ArcVal<T> {
     fn into_record(self) -> Record {
         (*self.x).clone().into_record()
     }

--- a/rust/template/lib.rs
+++ b/rust/template/lib.rs
@@ -34,6 +34,7 @@ use std::borrow;
 use std::ptr;
 use std::ffi;
 use std::boxed;
+use std::ops::Deref;
 use libc::size_t;
 
 pub mod valmap;

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -1322,7 +1322,8 @@ mkPatExpr' d varprefix ctx e@EBinding{..}            = do
     return $ Match (varprefix <+> pp exprVar) empty ((pp exprVar, Match pat cond []):subpatterns)
 mkPatExpr' d varprefix ctx e@ERef{..}                = do
     vname <- allocPatVar
-    subpattern <- mkPatExpr' d varprefix (CtxRef e ctx) $ enode exprPattern
+    subpattern <- mkPatExpr' d empty {- deref() returns reference, so not need for 'varprefix' anymore -}
+                             (CtxRef e ctx) $ enode exprPattern
     return $ Match (varprefix <+> vname) empty [("(*" <> pp vname <> ").deref()" , subpattern)]
 mkPatExpr' d varprefix ctx e                         = do
     vname <- allocPatVar

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -661,7 +661,7 @@ mkFunc d f@Function{..} | isJust funcDef =
     mkArg a = pp (name a) <> ":" <+> "&" <> (if argMut a then "mut" else empty) <+> mkType a
     tvars = case funcTypeVars f of
                  []  -> empty
-                 tvs -> "<" <> (hcat $ punctuate comma $ map ((<> ": Val") . pp) tvs) <> ">"
+                 tvs -> "<" <> (hcat $ punctuate comma $ map ((<> ": Eq + Ord + Clone + Hash + PartialEq + PartialOrd") . pp) tvs) <> ">"
 
 -- Generate Value type as an enum with one entry per type in types
 mkValType :: DatalogProgram -> S.Set Type -> S.Set Type -> Doc

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -1323,7 +1323,7 @@ mkPatExpr' d varprefix ctx e@EBinding{..}            = do
 mkPatExpr' d varprefix ctx e@ERef{..}                = do
     vname <- allocPatVar
     subpattern <- mkPatExpr' d varprefix (CtxRef e ctx) $ enode exprPattern
-    return $ Match (varprefix <+> vname) empty [(pp vname <> ".deref()" , subpattern)]
+    return $ Match (varprefix <+> vname) empty [("(*" <> pp vname <> ").deref()" , subpattern)]
 mkPatExpr' d varprefix ctx e                         = do
     vname <- allocPatVar
     return $ Match (varprefix <+> vname) 

--- a/src/Language/DifferentialDatalog/ECtx.hs
+++ b/src/Language/DifferentialDatalog/ECtx.hs
@@ -42,6 +42,7 @@ module Language.DifferentialDatalog.ECtx(
      ctxIsBinding,
      ctxIsTyped,
      ctxIsRuleRCond,
+     ctxInRuleRHSPositivePattern,
      ctxInRuleRHSPattern,
      ctxIsFunc)
 where
@@ -110,13 +111,27 @@ ctxIsRuleRCond _              = False
 -- | True if context is inside a positive right-hand-side literal of a
 -- rule, in a pattern expression, i.e., an expression where new
 -- variables can be declared.
+ctxInRuleRHSPositivePattern :: ECtx -> Bool
+ctxInRuleRHSPositivePattern (CtxRuleRAtom rl idx) = rhsPolarity $ ruleRHS rl !! idx
+ctxInRuleRHSPositivePattern CtxStruct{..}         = ctxInRuleRHSPositivePattern ctxPar
+ctxInRuleRHSPositivePattern CtxTuple{..}          = ctxInRuleRHSPositivePattern ctxPar
+ctxInRuleRHSPositivePattern CtxTyped{..}          = ctxInRuleRHSPositivePattern ctxPar
+ctxInRuleRHSPositivePattern CtxBinding{..}        = ctxInRuleRHSPositivePattern ctxPar
+ctxInRuleRHSPositivePattern CtxRef{..}            = ctxInRuleRHSPositivePattern ctxPar
+ctxInRuleRHSPositivePattern _                     = False
+
+-- | True if context is inside a (positive or negative) right-hand-side literal of a
+-- rule, in a pattern expression, i.e., an expression where new
+-- variables can be declared.
 ctxInRuleRHSPattern :: ECtx -> Bool
-ctxInRuleRHSPattern (CtxRuleRAtom rl idx) = rhsPolarity $ ruleRHS rl !! idx
+ctxInRuleRHSPattern (CtxRuleRAtom rl idx) = True
 ctxInRuleRHSPattern CtxStruct{..}         = ctxInRuleRHSPattern ctxPar
 ctxInRuleRHSPattern CtxTuple{..}          = ctxInRuleRHSPattern ctxPar
 ctxInRuleRHSPattern CtxTyped{..}          = ctxInRuleRHSPattern ctxPar
 ctxInRuleRHSPattern CtxBinding{..}        = ctxInRuleRHSPattern ctxPar
+ctxInRuleRHSPattern CtxRef{..}            = ctxInRuleRHSPattern ctxPar
 ctxInRuleRHSPattern _                     = False
+
 
 ctxIsFunc :: ECtx -> Bool
 ctxIsFunc CtxFunc{} = True

--- a/src/Language/DifferentialDatalog/NS.hs
+++ b/src/Language/DifferentialDatalog/NS.hs
@@ -163,4 +163,5 @@ ctxMVars d ctx =
          CtxUnOp _ _              -> ([], plvars ++ prvars)
          CtxBinding _ _           -> (plvars, prvars)
          CtxTyped _ _             -> (plvars, prvars)
+         CtxRef _ _               -> (plvars, prvars)
     where (plvars, prvars) = ctxMVars d $ ctxParent ctx

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -527,6 +527,7 @@ mkLit (Just w) v | w == 0              = fail "Unsigned literals must have width
                  | otherwise           = fail "Value exceeds specified width"
 
 etable = [[postf $ choice [postSlice, postApply, postField, postType]]
+         ,[pref  $ choice [preRef]]
          ,[pref  $ choice [prefix "~" BNeg]]
          ,[pref  $ choice [prefix "not" Not]]
          ,[binary "%" Mod AssocLeft,
@@ -574,6 +575,7 @@ dotcall = (,) <$ isapply <*> (dot *> funcIdent) <*> (parens $ commaSep expr)
 
 etype = reservedOp ":" *> typeSpecSimple
 
+preRef = (\start e -> E $ ERef (start, snd $ pos e) e) <$> getPosition <* reservedOp "&"
 prefix n fun = (\start e -> E $ EUnOp (start, snd $ pos e) fun e) <$> getPosition <* reservedOp n
 binary n fun  = Infix $ (\le re -> E $ EBinOp (fst $ pos le, snd $ pos re) fun le re) <$ reservedOp n
 sbinary n fun = Infix $ (\l  r  -> E $ fun (fst $ pos l, snd $ pos r) l r) <$ reservedOp n

--- a/src/Language/DifferentialDatalog/Statement.hs
+++ b/src/Language/DifferentialDatalog/Statement.hs
@@ -150,7 +150,7 @@ convertStatement (IfStatement p c s (Just e)) =
         rules1' = addRhsToRules (RHSCondition $ eNot c) rules1 in
     rules0' ++ rules1'
 convertStatement (MatchStatement p e c) =
-    let rulesList = map (\(co, s) -> convertStatement s) c
+    let rulesList = map (convertStatement . snd) c
         matchList = explodeMatchCases $ map fst c
         matchExpressions = map (\l -> RHSCondition $ eMatch e l) matchList
     in concat $ zipWith addRhsToRules matchExpressions rulesList

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -49,6 +49,7 @@ module Language.DifferentialDatalog.Type(
     funcTypeArgSubsts,
     sET_TYPES,
     gROUP_TYPE,
+    rEF_TYPE,
     checkIterable,
     typeIterType
 ) where

--- a/test/datalog_tests/constr.fail.ast.expected
+++ b/test/datalog_tests/constr.fail.ast.expected
@@ -1,6 +1,6 @@
 Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 2, column 23):
 unexpected '{'
-expecting "import", "typedef", "extern", "input", "output", "relation", "function", variable name, relation name, "for" or end of input
+expecting "import", "typedef", "extern", "input", "output", "relation", "function", variable name, "&", relation name, "for" or end of input
 
 error: ./test/datalog_tests/constr.fail.dl:4:13-4:29: Multiple definitions of constructor C at the following locations:
   ./test/datalog_tests/constr.fail.dl:4:13-4:29

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -51,6 +51,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -11,6 +11,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 function fmain (a1: foolib.lib.Rlib): foolib.ns1.m1.R1 =
@@ -50,6 +51,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -66,6 +66,7 @@ extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
 extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
 extern function std.str_to_lower (s: string): string
 extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -133,6 +133,7 @@ extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
 extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
 extern function std.str_to_lower (s: string): string
 extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -118,6 +118,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -72,6 +72,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef uuid = bit<128>
@@ -117,6 +118,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -61,6 +61,7 @@ extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
 extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
 extern function std.str_to_lower (s: string): string
 extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -10,6 +10,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function std.__builtin_2string (x: 'X): string
@@ -45,6 +46,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -46,6 +46,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -5,6 +5,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function std.__builtin_2string (x: 'X): string
@@ -40,6 +41,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -56,6 +56,7 @@ extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
 extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
 extern function std.str_to_lower (s: string): string
 extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -41,6 +41,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -65,6 +65,7 @@ extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
 extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
 extern function std.str_to_lower (s: string): string
 extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -458,6 +459,10 @@ pub fn std_parse_dec_u64(s: &arcval::DDString) -> std_Option<u64> {
 
 pub fn std_string_join(strings: &std_Vec<arcval::DDString>, sep: &arcval::DDString) -> arcval::DDString {
     arcval::DDString::from(strings.x.iter().map(|s|s.str()).collect::<Vec<&str>>().join(sep.as_str()))
+}
+
+pub fn std_string_split(s: &arcval::DDString, sep: &arcval::DDString) -> std_Vec<arcval::DDString> {
+    std_Vec{x: s.str().split(sep.str()).map(|x| arcval::DDString::from_str(x)).collect()}
 }
 
 pub fn std_str_to_lower(s: &arcval::DDString) -> arcval::DDString {

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -14,6 +14,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function std.__builtin_2string (x: 'X): string
@@ -49,6 +50,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -99,6 +101,14 @@ use std::iter::FromIterator;
 
 const XX_SEED1: u64 = 0x23b691a751d0e108;
 const XX_SEED2: u64 = 0x20b09801dce5ff84;
+
+// Ref
+pub type std_Ref<A> = arcval::ArcVal<A>;
+
+pub fn std_ref_new<A: Clone>(x: &A) -> std_Ref<A> {
+    arcval::ArcVal::from(x.clone())
+}
+
 
 // Option
 fn option2std<T: Clone>(x: Option<T>) -> std_Option<T> {

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -50,6 +50,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
@@ -98,6 +99,7 @@ use std::collections::btree_map;
 use std::vec::{Vec};
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FromIterator;
+use std::ops;
 
 const XX_SEED1: u64 = 0x23b691a751d0e108;
 const XX_SEED2: u64 = 0x20b09801dce5ff84;
@@ -116,6 +118,17 @@ fn option2std<T: Clone>(x: Option<T>) -> std_Option<T> {
         None => std_Option::std_None,
         Some(v) => std_Option::std_Some{x: v}
     }
+}
+
+// Range
+pub fn std_range<A: Clone + Ord + ops::Add<Output = A> + PartialOrd>(from: &A, to: &A, step: &A) -> std_Vec<A> {
+    let mut vec = std_Vec::new();
+    let mut x = from.clone();
+    while x <= *to {
+        vec.push(x.clone());
+        x = x + step.clone();
+    };
+    vec
 }
 
 // Vector

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -13,7 +13,7 @@ typedef C = C{f1: string, f2: string}
 typedef Disaggregate = Disaggregate{x: string, y: string}
 typedef ExternalId = ExternalId{host: bit<64>, id: (string, string)}
 typedef ExternalIds = ExternalIds{host: bit<64>, ids: std.Map<string,string>}
-typedef Filtered = Filtered{r: string}
+typedef Filtered = Filtered{r: std.Ref<Referenced>}
 typedef FooStruct = Option1{f1: bigint, f2: IPAddr, f3: (bool, string)} | Option2{f4: bit<32>, f5: IPAddr}
 typedef Gangster = Gangster{nickname: string, name: string}
 typedef HostAddress = HostAddress{host: bit<64>, addr: string}
@@ -518,4 +518,4 @@ ToAllocate(.name=name, .ids=ids) :- Request(.name=name, .id=id), not Realized(.n
 Allocated(.name=name, .xs=xs) :- Realized(.name=name, .id=_, .x=x), var xs = Aggregate((name), std.group2set(x)).
 Allocation(.name=name, .id=id, .x=x) :- ToAllocate(.name=name, .ids=ids), Allocated(.name=name, .xs=xs), var allocation = FlatMap(allocate_u32(xs, ids, ((32'd1 << 32'd24) - 32'd1))), (var id, var x) = allocation.
 Referee(.r=std.ref_new(r)) :- Referenced[(r@ Referenced{.x=_, .y=std.Some{.x=_}})].
-Filtered(.r=str) :- Referee(.r=(&Referenced{.x=true, .y=std.Some{.x=str}})).
+Filtered(.r=r.r) :- Referee[(r@ Referee{.r=(&Referenced{.x=true, .y=_})})].

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -289,6 +289,7 @@ extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
 extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
 extern function std.str_to_lower (s: string): string
 extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -14,6 +14,7 @@ typedef Disaggregate = Disaggregate{x: string, y: string}
 typedef ExternalId = ExternalId{host: bit<64>, id: (string, string)}
 typedef ExternalIds = ExternalIds{host: bit<64>, ids: std.Map<string,string>}
 typedef Filtered = Filtered{r: std.Ref<Referenced>}
+typedef Filtered2 = Filtered2{r: std.Ref<Referee2>}
 typedef FooStruct = Option1{f1: bigint, f2: IPAddr, f3: (bool, string)} | Option2{f4: bit<32>, f5: IPAddr}
 typedef Gangster = Gangster{nickname: string, name: string}
 typedef HostAddress = HostAddress{host: bit<64>, addr: string}
@@ -33,6 +34,7 @@ typedef R7 = R7{f1: bigint, f2: bit<16>} | R7Other{}
 typedef Reach = Reach{s1: station, s2: station}
 typedef Realized = Realized{name: string, id: string, x: bit<32>}
 typedef Referee = Referee{r: std.Ref<Referenced>}
+typedef Referee2 = Referee2{r: Referenced}
 typedef Referenced = Referenced{x: bool, y: std.Option<string>}
 typedef Rel1 = Rel1{x: bigint, y: IPAddr}
 typedef Rel2 = Rel2{x: bigint, z: FooStruct}
@@ -353,6 +355,7 @@ output relation Disaggregate [Disaggregate]
 output relation ExternalId [ExternalId]
 input relation ExternalIds [ExternalIds]
 output relation Filtered [Filtered]
+output relation Filtered2 [Filtered2]
 input relation Gangster [Gangster]
 output relation HostAddress [HostAddress]
 input relation HostAddresses [HostAddresses]
@@ -370,6 +373,7 @@ output relation R7 [R7]
 output relation Reach [Reach]
 input relation Realized [Realized]
 output relation Referee [Referee]
+output relation Referee2 [std.Ref<Referee2>]
 input relation Referenced [Referenced]
 input relation Rel1 [Rel1]
 input relation Rel2 [Rel2]
@@ -519,3 +523,5 @@ Allocated(.name=name, .xs=xs) :- Realized(.name=name, .id=_, .x=x), var xs = Agg
 Allocation(.name=name, .id=id, .x=x) :- ToAllocate(.name=name, .ids=ids), Allocated(.name=name, .xs=xs), var allocation = FlatMap(allocate_u32(xs, ids, ((32'd1 << 32'd24) - 32'd1))), (var id, var x) = allocation.
 Referee(.r=std.ref_new(r)) :- Referenced[(r@ Referenced{.x=_, .y=std.Some{.x=_}})].
 Filtered(.r=r.r) :- Referee[(r@ Referee{.r=(&Referenced{.x=true, .y=_})})].
+Referee2[std.ref_new(Referee2{.r=r})] :- Referenced[r].
+Filtered2(.r=r) :- Referee2[(r@ (&Referee2{.r=Referenced{.x=true, .y=_}}))].

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -13,6 +13,7 @@ typedef C = C{f1: string, f2: string}
 typedef Disaggregate = Disaggregate{x: string, y: string}
 typedef ExternalId = ExternalId{host: bit<64>, id: (string, string)}
 typedef ExternalIds = ExternalIds{host: bit<64>, ids: std.Map<string,string>}
+typedef Filtered = Filtered{r: string}
 typedef FooStruct = Option1{f1: bigint, f2: IPAddr, f3: (bool, string)} | Option2{f4: bit<32>, f5: IPAddr}
 typedef Gangster = Gangster{nickname: string, name: string}
 typedef HostAddress = HostAddress{host: bit<64>, addr: string}
@@ -31,6 +32,8 @@ typedef R6 = R6{f: bigint}
 typedef R7 = R7{f1: bigint, f2: bit<16>} | R7Other{}
 typedef Reach = Reach{s1: station, s2: station}
 typedef Realized = Realized{name: string, id: string, x: bit<32>}
+typedef Referee = Referee{r: std.Ref<Referenced>}
+typedef Referenced = Referenced{x: bool, y: std.Option<string>}
 typedef Rel1 = Rel1{x: bigint, y: IPAddr}
 typedef Rel2 = Rel2{x: bigint, z: FooStruct}
 typedef Rel3 = Rel3{x: bigint, y: IPAddr, z: FooStruct}
@@ -69,6 +72,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef string_syn = string
@@ -268,6 +272,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -347,6 +352,7 @@ input relation Blacklist [Blacklist]
 output relation Disaggregate [Disaggregate]
 output relation ExternalId [ExternalId]
 input relation ExternalIds [ExternalIds]
+output relation Filtered [Filtered]
 input relation Gangster [Gangster]
 output relation HostAddress [HostAddress]
 input relation HostAddresses [HostAddresses]
@@ -363,6 +369,8 @@ output relation R6 [R6]
 output relation R7 [R7]
 output relation Reach [Reach]
 input relation Realized [Realized]
+output relation Referee [Referee]
+input relation Referenced [Referenced]
 input relation Rel1 [Rel1]
 input relation Rel2 [Rel2]
 output relation Rel3 [Rel3]
@@ -509,3 +517,5 @@ Allocation(.name=name, .id=id, .x=x) :- Request(.name=name, .id=id), Realized(.n
 ToAllocate(.name=name, .ids=ids) :- Request(.name=name, .id=id), not Realized(.name=name, .id=id, .x=_), var ids = Aggregate((name), std.group2vec(id)).
 Allocated(.name=name, .xs=xs) :- Realized(.name=name, .id=_, .x=x), var xs = Aggregate((name), std.group2set(x)).
 Allocation(.name=name, .id=id, .x=x) :- ToAllocate(.name=name, .ids=ids), Allocated(.name=name, .xs=xs), var allocation = FlatMap(allocate_u32(xs, ids, ((32'd1 << 32'd24) - 32'd1))), (var id, var x) = allocation.
+Referee(.r=std.ref_new(r)) :- Referenced[(r@ Referenced{.x=_, .y=std.Some{.x=_}})].
+Filtered(.r=str) :- Referee(.r=(&Referenced{.x=true, .y=std.Some{.x=str}})).

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -274,6 +274,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -220,3 +220,15 @@ commit;
 
 echo Allocation after clear;
 dump Allocation;
+
+start;
+
+insert Referenced(true, std.Some{"hello"});
+
+commit;
+
+echo Referee;
+dump Referee;
+
+echo Filtered;
+dump Filtered;

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -232,3 +232,9 @@ dump Referee;
 
 echo Filtered;
 dump Filtered;
+
+echo Referee2;
+dump Referee2;
+
+echo Filtered2;
+dump Filtered2;

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -694,3 +694,11 @@ Referee(ref_new(r)) :-
 output relation Filtered(r: Ref<Referenced>)
 
 Filtered(r.r) :- r in Referee(.r = &Referenced{.x = true}).
+
+output relation &Referee2(r: Referenced)
+
+&Referee2(r) :- Referenced[r].
+
+output relation Filtered2(r: Ref<Referee2>)
+
+Filtered2(r) :- r in &Referee2(.r = Referenced{.x = true}).

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -691,6 +691,6 @@ output relation Referee(r: Ref<Referenced>)
 Referee(ref_new(r)) :-
     r in Referenced(_, Some{_}).
 
-output relation Filtered(r: string)
+output relation Filtered(r: Ref<Referenced>)
 
-Filtered(str) :- Referee(.r = &Referenced{.x = true, .y = Some{str}}).
+Filtered(r.r) :- r in Referee(.r = &Referenced{.x = true}).

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -681,3 +681,16 @@ Allocation(name, id, x) :-
     Allocated(name, xs),
     var allocation = FlatMap(allocate_u32(xs, ids, (32'd1 << 32'd24) - 32'd1)),
     (var id, var x) = allocation.
+
+/* Ref test */
+
+input relation Referenced(x: bool, y: Option<string>)
+
+output relation Referee(r: Ref<Referenced>)
+
+Referee(ref_new(r)) :-
+    r in Referenced(_, Some{_}).
+
+output relation Filtered(r: string)
+
+Filtered(str) :- Referee(.r = &Referenced{.x = true, .y = Some{str}}).

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -213,3 +213,7 @@ Allocation{"b","3",16777215}
 Allocation{"b","4",1}
 Allocation{"b","5",2}
 Allocation after clear
+Referee
+Referee{Referenced{true,std.Some{"hello"}}}
+Filtered
+Filtered{"hello"}

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -216,4 +216,4 @@ Allocation after clear
 Referee
 Referee{Referenced{true,std.Some{"hello"}}}
 Filtered
-Filtered{"hello"}
+Filtered{Referenced{true,std.Some{"hello"}}}

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -217,3 +217,7 @@ Referee
 Referee{Referenced{true,std.Some{"hello"}}}
 Filtered
 Filtered{Referenced{true,std.Some{"hello"}}}
+Referee2
+Referee2{Referenced{true,std.Some{"hello"}}}
+Filtered2
+Filtered2{Referee2{Referenced{true,std.Some{"hello"}}}}

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -156,6 +156,7 @@ extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
 extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
 extern function std.str_to_lower (s: string): string
 extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -141,6 +141,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -53,6 +53,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef tcp_pkt_t = TCPPkt{src: bit<16>, dst: bit<16>, flags: bit<9>}
@@ -140,6 +141,7 @@ extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.ref_new (x: 'A): std.Ref<'A>
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>


### PR DESCRIPTION
- `Ref<T>` is the DDlog shortcut to Rust's `Arc<T>` type
- syntax for declaring relations whose records are references:
 ```
 relation &Router(
     lr:                 nb.Logical_Router,
     dpname:             string,
     l3dgw_port:         Option<nb.Logical_Router_Port>,
     redirect_port_name: string,
     is_gateway:         bool,
     snat_external_ips:  Set<string>
 )
 ```
- Pattern matching relations and structs wrapped in a `Ref`
```
&RouterPort(.lrp = lrp,
                 .router = &Router{.lr = lr, .dpname = dpname, .snat_external_ips = external_ips},
                 .json_name = json_name,
                 .networks = networks)
```
- syntax in flux; no documentation yet