### PR TITLE
Improvements to Java and C bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ differential-datalog.iml
 TAGS
 tags
 *.facts
+*.jar
+java/test/span.java.dump

--- a/java/Makefile
+++ b/java/Makefile
@@ -2,7 +2,7 @@ CLASS = ddlogapi/DDLogAPI.class
 
 all: $(CLASS)
 
-%.class: %.java
+%.class: %.java ddlogapi_DDLogAPI.h
 	javac $<
 
 ddlogapi_DDLogAPI.h ddlogapi/DDLogApi.class: ddlogapi/DDLogAPI.java ddlogapi/DDLogCommand.java \

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,13 +1,12 @@
-CLASS = ddlogapi/DDLogAPI.class
+CLASS = ddlogapi/DDLogAPI.class ddlogapi/DDLogCommand.class ddlogapi/DDLogRecord.class
 
 all: $(CLASS)
 
 %.class: %.java ddlogapi_DDLogAPI.h
 	javac $<
 
-ddlogapi_DDLogAPI.h ddlogapi/DDLogApi.class: ddlogapi/DDLogAPI.java ddlogapi/DDLogCommand.java \
-                         ddlogapi/DDLogRecord.java
-	javac -h .  $<
+ddlogapi_DDLogAPI.h: ddlogapi/DDLogAPI.java
+	javac -h . $<
 
 clean:
 	rm -f *.class ddlogapi/*.class

--- a/java/ddlogapi/DDLogCommand.java
+++ b/java/ddlogapi/DDLogCommand.java
@@ -8,10 +8,10 @@ public class DDLogCommand {
     };
 
     public final Kind kind;
-    public final String table;
+    public final int table;
     public final DDLogRecord value;
 
-    public DDLogCommand(final Kind kind, final String table, final DDLogRecord value) {
+    public DDLogCommand(final Kind kind, final int table, final DDLogRecord value) {
         this.kind = kind;
         this.table = table;
         this.value = value;

--- a/java/test/Span.java
+++ b/java/test/Span.java
@@ -83,7 +83,8 @@ public class Span {
                     array[1] = new DDLogRecord(args[1].trim().replace("\"", ""));
                     DDLogRecord strct = DDLogRecord.makeStruct(relation, array);
 
-                    DDLogCommand c = new DDLogCommand(DDLogCommand.Kind.Insert, relation, strct);
+                    int id = this.api.getTableId(relation);
+                    DDLogCommand c = new DDLogCommand(DDLogCommand.Kind.Insert, id, strct);
                     this.commands.add(c);
                     if (this.terminator.equals(";")) {
                         DDLogCommand[] ca = this.commands.toArray(new DDLogCommand[0]);

--- a/java/test/span.sh
+++ b/java/test/span.sh
@@ -17,10 +17,13 @@ mkdir -p META-INF
 echo "Main-Class: Span" > META-INF/MANIFEST.MF
 # Create jar containing Span and the Ddlog API
 jar cmvf META-INF/MANIFEST.MF span.jar Span*.class ../ddlogapi/*.class
+rm -rf META-INF
 # Create a shared library containing all the native code: ddlogapi.c, libspan_ddlog.a
 gcc -shared -Wl,-soname,ddlogapi -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I../../rust/template ../ddlogapi.c ../ddlogapi_DDLogAPI.h -L../../test/datalog_tests/span_ddlog/target/release/ -lspan_ddlog -o libddlogapi.so
-# Run the java program pointing to the created shared library   
+# Run the java program pointing to the created shared library
 java -Djava.library.path=. -jar span.jar ../../test/datalog_tests/span.dat >span.java.dump
+# Compare outputs
+diff span.java.dump ../../test/datalog_tests/span.dump
 
 # Cleanup
 rm -rf META-INF *.class

--- a/java/test/span.sh
+++ b/java/test/span.sh
@@ -5,18 +5,18 @@ set -ex
 
 # Compile the span.dl DDlog program; generates
 # ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a and .so
-stack test --ta '-p span'
+#stack test --ta '-p span'
 # Build the Java library with the Ddlog API
 make -C ..
 # Force linking with the static library by deleting the dynamic library
 rm -f ../../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.so
-# Compile Span.java
-javac -cp .. Span.java
+# Compile SpanTest.java
+javac -cp .. SpanTest.java
 # Create manifest file for jar
 mkdir -p META-INF
-echo "Main-Class: Span" > META-INF/MANIFEST.MF
-# Create jar containing Span and the Ddlog API
-jar cmvf META-INF/MANIFEST.MF span.jar Span*.class ../ddlogapi/*.class
+echo "Main-Class: SpanTest" > META-INF/MANIFEST.MF
+# Create jar containing SpanTest.* classes and the Ddlog API
+jar cmvf META-INF/MANIFEST.MF span.jar SpanTest*.class ../ddlogapi/*.class
 rm -rf META-INF
 # Create a shared library containing all the native code: ddlogapi.c, libspan_ddlog.a
 gcc -shared -Wl,-soname,ddlogapi -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I../../rust/template ../ddlogapi.c ../ddlogapi_DDLogAPI.h -L../../test/datalog_tests/span_ddlog/target/release/ -lspan_ddlog -o libddlogapi.so

--- a/rust/template/cmd_parser/parse.rs
+++ b/rust/template/cmd_parser/parse.rs
@@ -87,35 +87,36 @@ fn test_command() {
     assert_eq!(parse_command(br"rollback;") , Ok((&br""[..], Command::Rollback)));
     assert_eq!(parse_command(br"insert Rel1(true);"),
                Ok((&br""[..], Command::Update(
-                   UpdCmd::Insert(Cow::from("Rel1"), Record::PosStruct(Cow::from("Rel1"), vec![Record::Bool(true)])),
+                   UpdCmd::Insert(RelIdentifier::RelName(Cow::from("Rel1")), Record::PosStruct(Cow::from("Rel1"), vec![Record::Bool(true)])),
                    true
                ))));
     assert_eq!(parse_command(br" insert Rel1[true];"),
                Ok((&br""[..], Command::Update(
-                   UpdCmd::Insert(Cow::from("Rel1"), Record::Bool(true)), true
+                   UpdCmd::Insert(RelIdentifier::RelName(Cow::from("Rel1")), Record::Bool(true)), true
                ))));
     assert_eq!(parse_command(br"delete Rel1[(true,false)];"),
                Ok((&br""[..], Command::Update(
-                   UpdCmd::Delete(Cow::from("Rel1"), Record::Tuple(vec![Record::Bool(true), Record::Bool(false)])), true
+                   UpdCmd::Delete(RelIdentifier::RelName(Cow::from("Rel1")), Record::Tuple(vec![Record::Bool(true), Record::Bool(false)])), true
                ))));
     assert_eq!(parse_command(br"delete_key Rel1 true;"),
                Ok((&br""[..], Command::Update(
-                   UpdCmd::DeleteKey(Cow::from("Rel1"), Record::Bool(true)), true
+                   UpdCmd::DeleteKey(RelIdentifier::RelName(Cow::from("Rel1")), Record::Bool(true)), true
                ))));
     assert_eq!(parse_command(br#"   delete NB.Logical_Router("foo", 0xabcdef1, true) , "#),
                Ok((&br""[..], Command::Update(
-                   UpdCmd::Delete(Cow::from("NB.Logical_Router"), Record::PosStruct(Cow::from("NB.Logical_Router"),
-                                                                    vec![Record::String("foo".to_string()),
-                                                                         Record::Int(0xabcdef1.to_bigint().unwrap()),
-                                                                         Record::Bool(true)])),
+                   UpdCmd::Delete(RelIdentifier::RelName(Cow::from("NB.Logical_Router")),
+                                  Record::PosStruct(Cow::from("NB.Logical_Router"),
+                                                    vec![Record::String("foo".to_string()),
+                                                         Record::Int(0xabcdef1.to_bigint().unwrap()),
+                                                         Record::Bool(true)])),
                    false
                ))));
 }
 
 named!(update<&[u8], UpdCmd>,
-    alt!(do_parse!(apply!(sym,"insert")     >> rec: rel_record >> (UpdCmd::Insert(rec.0, rec.1)))  |
-         do_parse!(apply!(sym,"delete")     >> rec: rel_record >> (UpdCmd::Delete(rec.0, rec.1)))  |
-         do_parse!(apply!(sym,"delete_key") >> rec: rel_key    >> (UpdCmd::DeleteKey(rec.0, rec.1))))
+    alt!(do_parse!(apply!(sym,"insert")     >> rec: rel_record >> (UpdCmd::Insert(RelIdentifier::RelName(rec.0), rec.1)))  |
+         do_parse!(apply!(sym,"delete")     >> rec: rel_record >> (UpdCmd::Delete(RelIdentifier::RelName(rec.0), rec.1)))  |
+         do_parse!(apply!(sym,"delete_key") >> rec: rel_key    >> (UpdCmd::DeleteKey(RelIdentifier::RelName(rec.0), rec.1))))
 );
 
 named!(rel_record<&[u8], (Name, Record)>,

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -51,6 +51,13 @@ typedef void ddlog_record;
 
 
 /*
+ * Get DDlog table id by name.
+ *
+ * On error, returns -1.
+ */
+extern table_id ddlog_get_table_id(const char* tname);
+
+/*
  * Create an instance of DDlog program.
  *
  * `workers` is the number of DDlog worker threads that will be
@@ -103,7 +110,7 @@ typedef void ddlog_record;
 extern ddlog_prog ddlog_run(unsigned int workers,
 			    bool do_store,
 			    bool (*cb)(void *arg,
-				       table_id tablie,
+				       table_id table,
 				       const ddlog_record *rec,
 				       bool polarity),
 			    void* cb_arg);
@@ -184,8 +191,7 @@ extern int ddlog_apply_ovsdb_updates(ddlog_prog hprog, const char *prefix,
  *
  * On error, returns a negative number and writes error message to stderr.
  */
-extern int ddlog_dump_ovsdb_deltaplus_table(ddlog_prog hprog,
-                                            const char *table,
+extern int ddlog_dump_ovsdb_deltaplus_table(ddlog_prog hprog, table_id table,
                                             char **json);
 
 /*
@@ -201,8 +207,7 @@ extern int ddlog_dump_ovsdb_deltaplus_table(ddlog_prog hprog,
  *
  * On error, returns a negative number and write error message to stderr.
  */
-extern int ddlog_dump_ovsdb_deltaminus_table(ddlog_prog hprog,
-                                             const char *table,
+extern int ddlog_dump_ovsdb_deltaminus_table(ddlog_prog hprog, table_id table,
                                              char **json);
 
 /*
@@ -218,8 +223,7 @@ extern int ddlog_dump_ovsdb_deltaminus_table(ddlog_prog hprog,
  *
  * On error, returns a negative number and writes error message to stderr.
  */
-extern int ddlog_dump_ovsdb_deltaupdate_table(ddlog_prog hprog,
-                                              const char *table,
+extern int ddlog_dump_ovsdb_deltaupdate_table(ddlog_prog hprog, table_id table,
                                               char **json);
 
 /*
@@ -247,14 +251,13 @@ extern int ddlog_apply_updates(ddlog_prog prog, ddlog_cmd **upds, size_t n);
  * On success, returns `0`. On error, returns a negative value and
  * writes error message to stderr.
  */
-extern int ddlog_clear_relation(ddlog_prog prog, const char *table);
+extern int ddlog_clear_relation(ddlog_prog prog, table_id table);
 
 /*
  * Dump the content of an output table by invoking `cb` for each value
  * in the table.
  *
- * `table` is a null-terminated string that specifies the name of the
- * table.  `cb_arg` is an opaque argument passed to each invocation.
+ * `cb_arg` is an opaque argument passed to each invocation.
  *
  * Requires that `hprog` was created by calling `ddlog_run()` with
  * `do_store` flag set to `true`.  Fails otherwise.
@@ -265,7 +268,7 @@ extern int ddlog_clear_relation(ddlog_prog prog, const char *table);
  * The content of the table returned by this function represents
  * database state after the last committed transaction.
  */
-extern int ddlog_dump_table(ddlog_prog prog, const char *table,
+extern int ddlog_dump_table(ddlog_prog prog, table_id table,
                             bool (*cb)(uintptr_t arg, const ddlog_record *rec),
                             uintptr_t cb_arg);
 
@@ -737,39 +740,36 @@ extern const ddlog_record* ddlog_get_struct_field(const ddlog_record* rec,
 /*
  * Create an insert command.
  *
- * `table` is the null-terminated name of the table to insert to.  `rec`
- * is the record to insert.  The function takes ownership of this
- * record.
+ * `table` is the table to insert to.  `rec` is the record to insert.
+ * The function takes ownership of this record.
  *
  * Returns pointer to a new command, which can be sent to DDlog by calling
  * `ddlog_apply_updates()`.
  */
-extern ddlog_cmd* ddlog_insert_cmd(const char *table, ddlog_record *rec);
+extern ddlog_cmd* ddlog_insert_cmd(table_id table, ddlog_record *rec);
 
 /*
  * Create delete-by-value command.
  *
- * `table` is the null-terminated name of the table to delete from.
- * `rec` is the record to delete.  The function takes ownership of this
- * record.
+ * `table` is the table to delete from. `rec` is the record to delete.
+ * The function takes ownership of this record.
  *
  * Returns pointer to a new command, which can be sent to DDlog by calling
  * `ddlog_apply_updates()`.
  */
-extern ddlog_cmd* ddlog_delete_val_cmd(const char *table, ddlog_record *rec);
+extern ddlog_cmd* ddlog_delete_val_cmd(table_id table, ddlog_record *rec);
 
 /*
  * Create delete-by-key command.
  *
- * `table` is the null-terminated name of the table to delete from.
- * `rec` is the key to delete.  The table must have a primary key and
- * `rec` type must match the type of the key.  The function takes
- * ownership of `rec`.
+ * `table` is the table to delete from.  `rec` is the key to delete.  The
+ * table must have a primary key and `rec` type must match the type of the
+ * key.  The function takes ownership of `rec`.
  *
  * Returns pointer to a new command, which can be sent to DDlog by calling
  * `ddlog_apply_updates()`.
  *
  */
-extern ddlog_cmd* ddlog_delete_key_cmd(const char *table, ddlog_record *rec);
+extern ddlog_cmd* ddlog_delete_key_cmd(table_id table, ddlog_record *rec);
 
 #endif

--- a/rust/template/ddlog_ovsdb_test.c
+++ b/rust/template/ddlog_ovsdb_test.c
@@ -6,7 +6,7 @@
 
 int main(int args, char *argv)
 {
-	ddlog_prog prog = ddlog_run(1);
+	ddlog_prog prog = ddlog_run(1, true, NULL, 0);
 	if (prog == NULL) {
 		fprintf(stderr, "failed to initialize DDlog program\n");
 		return -1;

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -1088,3 +1088,26 @@ fn test_enum() {
                                         f3: Foo{f1: 0}};
     assert_eq!(DummyEnum::from_record(&enm.clone().into_record()), Ok(enm));
 }
+
+
+#[macro_export]
+macro_rules! decl_val_enum_into_record {
+    ( $n:ident, <$( $targ:ident),*>, $($cons:ident {$arg:ident} ),* ) => {
+        impl <$($targ: $crate::record::IntoRecord),*> $crate::record::IntoRecord for $n<$($targ),*> {
+            fn into_record(self) -> $crate::record::Record {
+                match self {
+                    $($n::$cons{$arg} => $arg.into_record()),*
+                }
+            }
+        }
+    };
+    ( $n:ident, <$( $targ:ident),*>, $($cons:ident ($arg:ident) ),* ) => {
+        impl <$($targ: $crate::record::IntoRecord),*> $crate::record::IntoRecord for $n<$($targ),*> {
+            fn into_record(self) -> $crate::record::Record {
+                match self {
+                    $($n::$cons($arg) => $arg.into_record()),*
+                }
+            }
+        }
+    };
+}

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -67,15 +67,20 @@ pub extern "C" fn ddlog_dump_ovsdb_deltaplus_table(prog:  *const HDDlog,
         return -1;
     };
     let prog = unsafe {sync::Arc::from_raw(prog)};
-    let res = match dump_deltaplus_table(&mut prog.1.lock().unwrap(), table) {
-        Ok(jinserts) => {
-            unsafe { *json = jinserts.into_raw() };
-            0
-        },
-        Err(e) => {
-            eprintln!("ddlog_dump_ovsdb_deltaplus_table(): error: {}", e);
-            -1
+    let res = if let Some(ref db) = prog.1 {
+        match dump_deltaplus_table(&mut db.lock().unwrap(), table) {
+            Ok(jinserts) => {
+                unsafe { *json = jinserts.into_raw() };
+                0
+            },
+            Err(e) => {
+                eprintln!("ddlog_dump_ovsdb_deltaplus_table(): error: {}", e);
+                -1
+            }
         }
+    } else {
+        eprintln!("ddlog_dump_ovsdb_deltaplus_table(): cannot dump table: ddlog_run() was invoked with do_store flag set to false");
+        -1
     };
     sync::Arc::into_raw(prog);
     res
@@ -104,15 +109,20 @@ pub extern "C" fn ddlog_dump_ovsdb_deltaminus_table(prog:  *const HDDlog,
         return -1;
     };
     let prog = unsafe {sync::Arc::from_raw(prog)};
-    let res = match dump_deltaminus_table(&mut prog.1.lock().unwrap(), table) {
-        Ok(jdeletes) => {
-            unsafe { *json = jdeletes.into_raw() };
-            0
-        },
-        Err(e) => {
-            eprintln!("ddlog_dump_ovsdb_deltaminus_table(): error: {}", e);
-            -1
+    let res = if let Some(ref db) = prog.1 {
+        match dump_deltaminus_table(&mut db.lock().unwrap(), table) {
+            Ok(jdeletes) => {
+                unsafe { *json = jdeletes.into_raw() };
+                0
+            },
+            Err(e) => {
+                eprintln!("ddlog_dump_ovsdb_deltaminus_table(): error: {}", e);
+                -1
+            }
         }
+    } else {
+        eprintln!("ddlog_dump_ovsdb_deltaminus_table(): cannot dump table: ddlog_run() was invoked with do_store flag set to false");
+        -1
     };
     sync::Arc::into_raw(prog);
     res
@@ -141,15 +151,20 @@ pub extern "C" fn ddlog_dump_ovsdb_deltaupdate_table(prog:  *const HDDlog,
         return -1;
     };
     let prog = unsafe {sync::Arc::from_raw(prog)};
-    let res = match dump_deltaupdate_table(&mut prog.1.lock().unwrap(), table) {
-        Ok(jupdates) => {
-            unsafe { *json = jupdates.into_raw() };
-            0
-        },
-        Err(e) => {
-            eprintln!("ddlog_dump_ovsdb_deltaupdate_table(): error: {}", e);
-            -1
+    let res = if let Some(ref db) = prog.1 {
+        match dump_deltaupdate_table(&mut db.lock().unwrap(), table) {
+            Ok(jupdates) => {
+                unsafe { *json = jupdates.into_raw() };
+                0
+            },
+            Err(e) => {
+                eprintln!("ddlog_dump_ovsdb_deltaupdate_table(): error: {}", e);
+                -1
+            }
         }
+    } else {
+        eprintln!("ddlog_dump_ovsdb_deltaupdate_table(): cannot dump table: ddlog_run() was invoked with do_store flag set to false");
+        -1
     };
     sync::Arc::into_raw(prog);
     res

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -61,9 +61,9 @@ fn apply_updates(prog: &mut RunningProgram<Value>, prefix: *const c_char, update
 /// On error, returns a negative number and writes error message to stderr.
 #[no_mangle]
 pub extern "C" fn ddlog_dump_ovsdb_deltaplus_table(prog:  *const HDDlog,
-                                                   table: *const c_char,
+                                                   table: libc::size_t,
                                                    json:  *mut *mut c_char) -> c_int {
-    if json.is_null() || prog.is_null() || table.is_null() {
+    if json.is_null() || prog.is_null() {
         return -1;
     };
     let prog = unsafe {sync::Arc::from_raw(prog)};
@@ -86,11 +86,9 @@ pub extern "C" fn ddlog_dump_ovsdb_deltaplus_table(prog:  *const HDDlog,
     res
 }
 
-fn dump_deltaplus_table(db: &mut valmap::ValMap, table: *const c_char) -> Result<CString, String> {
-    let table_str = unsafe{ CStr::from_ptr(table) }.to_str().map_err(|e| format!("{}", e))?;
-    let relid = output_relname_to_id(table_str).ok_or_else(||format!("unknown output relation {}", table_str))?;
+fn dump_deltaplus_table(db: &mut valmap::ValMap, table: libc::size_t) -> Result<CString, String> {
     let cmds: Result<Vec<String>, String> =
-        db.get_rel(relid as RelId)
+        db.get_rel(table as RelId)
           .iter().map(|v| record_into_insert_str(v.clone().into_record())).collect();
     Ok(unsafe{ CString::from_vec_unchecked(cmds?.join(",").into_bytes()) } )
 }
@@ -103,9 +101,9 @@ fn dump_deltaplus_table(db: &mut valmap::ValMap, table: *const c_char) -> Result
 /// On error, returns a negative number and writes error message to stderr.
 #[no_mangle]
 pub extern "C" fn ddlog_dump_ovsdb_deltaminus_table(prog:  *const HDDlog,
-                                                    table: *const c_char,
+                                                    table: libc::size_t,
                                                     json:  *mut *mut c_char) -> c_int {
-    if json.is_null() || prog.is_null() || table.is_null() {
+    if json.is_null() || prog.is_null() {
         return -1;
     };
     let prog = unsafe {sync::Arc::from_raw(prog)};
@@ -128,11 +126,9 @@ pub extern "C" fn ddlog_dump_ovsdb_deltaminus_table(prog:  *const HDDlog,
     res
 }
 
-fn dump_deltaminus_table(db: &mut valmap::ValMap, table: *const c_char) -> Result<CString, String> {
-    let table_str = unsafe{ CStr::from_ptr(table) }.to_str().map_err(|e| format!("{}", e))?;
-    let relid = output_relname_to_id(table_str).ok_or_else(||format!("unknown output relation {}", table_str))?;
+fn dump_deltaminus_table(db: &mut valmap::ValMap, table: libc::size_t) -> Result<CString, String> {
     let cmds: Result<Vec<String>, String> =
-        db.get_rel(relid as RelId)
+        db.get_rel(table as RelId)
           .iter().map(|v| record_into_delete_str(v.clone().into_record())).collect();
     Ok(unsafe{ CString::from_vec_unchecked(cmds?.join(",").into_bytes()) } )
 }
@@ -145,9 +141,9 @@ fn dump_deltaminus_table(db: &mut valmap::ValMap, table: *const c_char) -> Resul
 /// On error, returns a negative number and writes error message to stderr.
 #[no_mangle]
 pub extern "C" fn ddlog_dump_ovsdb_deltaupdate_table(prog:  *const HDDlog,
-                                                     table: *const c_char,
+                                                     table: libc::size_t,
                                                      json:  *mut *mut c_char) -> c_int {
-    if json.is_null() || prog.is_null() || table.is_null() {
+    if json.is_null() || prog.is_null() {
         return -1;
     };
     let prog = unsafe {sync::Arc::from_raw(prog)};
@@ -170,11 +166,9 @@ pub extern "C" fn ddlog_dump_ovsdb_deltaupdate_table(prog:  *const HDDlog,
     res
 }
 
-fn dump_deltaupdate_table(db: &mut valmap::ValMap, table: *const c_char) -> Result<CString, String> {
-    let table_str = unsafe{ CStr::from_ptr(table) }.to_str().map_err(|e| format!("{}", e))?;
-    let relid = output_relname_to_id(table_str).ok_or_else(||format!("unknown output relation {}", table_str))?;
+fn dump_deltaupdate_table(db: &mut valmap::ValMap, table: libc::size_t) -> Result<CString, String> {
     let cmds: Result<Vec<String>, String> =
-        db.get_rel(relid as RelId)
+        db.get_rel(table as RelId)
           .iter().map(|v| record_into_update_str(v.clone().into_record())).collect();
     Ok(unsafe{ CString::from_vec_unchecked(cmds?.join(",").into_bytes()) } )
 }

--- a/rust/template/ovsdb/lib.rs
+++ b/rust/template/ovsdb/lib.rs
@@ -77,13 +77,14 @@ fn cmd_from_row_update(table: &str, uuid: String, update: Value, cmds: &mut Vec<
             };
             if old.is_some() {
                 // delete_key
-                cmds.push(UpdCmd::DeleteKey(Cow::from(table.to_owned()), uuid.clone()))
+                cmds.push(UpdCmd::DeleteKey(RelIdentifier::RelName(Cow::from(table.to_owned())), uuid.clone()))
             };
             if new.is_some() {
                 let mut fields = new.unwrap()?;
                 fields.push((Cow::from("_uuid"), uuid));
                 // insert
-                cmds.push(UpdCmd::Insert(Cow::from(table.to_owned()), Record::NamedStruct(Cow::from(table.to_owned()), fields)))
+                cmds.push(UpdCmd::Insert(RelIdentifier::RelName(Cow::from(table.to_owned())),
+                                         Record::NamedStruct(Cow::from(table.to_owned()), fields)))
             };
             Ok(())
         },

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -681,7 +681,7 @@ mkValType d types grp_types =
     "        }"                                                                             $$
     "    }"                                                                                 $$
     "}"                                                                                     $$
-    "decl_enum_into_record!(Value, <>," <+> decl_enum_entries <> ");"                       $$
+    "decl_val_enum_into_record!(Value, <>," <+> decl_enum_entries <> ");"                   $$
     (vcat $ map mkgrptype $ S.toList grp_types)
     where
     consname t = mkValConstructorName' d t


### PR DESCRIPTION
- added flag to `ddlog_run()` to control caching of output relations in ddlog
- added callback to notify the client about every record update
- replace relation names with numeric IDs throughout the API
- reflection-based API to convert Java objects to DDlog records and back (still wip)