### PR TITLE
optimization: avoid `distinct_total` for some output relations

### DIFF
--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -411,7 +411,7 @@ impl<V:Val> Program<V>
                                     };
                                     /* don't distinct input collections, as this is already done by the set_update logic */
                                     if !r.input && r.distinct {
-                                        collection = with_prof_context(&r.name,
+                                        collection = with_prof_context(&format!("{}.distinct_total", r.name),
                                                                        ||collection.distinct_total());
                                     }
                                     /* create arrangements */

--- a/rust/template/differential_datalog/variable.rs
+++ b/rust/template/differential_datalog/variable.rs
@@ -56,7 +56,7 @@ impl<'a, G: Scope, D: Default+Data+Hashable> Drop for Variable<'a, G, D> where G
     fn drop(&mut self) {
         if let Some(feedback) = self.feedback.take() {
             with_prof_context(
-                &self.name,
+                &format!("Variable: {}", self.name),
                 ||self.current.distinct()
                             .inner
                             .map(|(x,t,d)| (x, Product::new(t.outer, t.inner+1), d))

--- a/src/Language/DifferentialDatalog/DatalogProgram.hs
+++ b/src/Language/DifferentialDatalog/DatalogProgram.hs
@@ -41,7 +41,7 @@ module Language.DifferentialDatalog.DatalogProgram (
 ) 
 where
 
-import qualified Data.Graph.Inductive as G
+import qualified Data.Graph.Inductive           as G
 import qualified Data.Map as M
 import Data.Maybe
 import Control.Monad.Identity

--- a/src/Language/DifferentialDatalog/Expr.hs
+++ b/src/Language/DifferentialDatalog/Expr.hs
@@ -224,7 +224,6 @@ exprVars e = nub $ exprCollect (\case
                                 _        -> [])
                                (++) e
 
-
 -- Variables declared inside expression, visible in the code that follows the expression
 exprVarDecls :: ECtx -> Expr -> [(String, ECtx)]
 exprVarDecls ctx e =

--- a/src/Language/DifferentialDatalog/Relation.hs
+++ b/src/Language/DifferentialDatalog/Relation.hs
@@ -1,0 +1,105 @@
+{-
+Copyright (c) 2018 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-}
+
+{-# LANGUAGE TupleSections, LambdaCase, RecordWildCards #-}
+
+{- | 
+Module     : Relation
+Description: Helper functions for manipulating Relations.
+-}
+module Language.DifferentialDatalog.Relation (
+    relRules,
+    relIsRecursive,
+    relIsDistinctByConstruction,
+    relIsDistinct
+) 
+where
+
+import qualified Data.Graph.Inductive           as G
+import qualified Data.Graph.Inductive.Query.DFS as G
+import Data.Maybe
+import Data.List
+
+import Language.DifferentialDatalog.Name
+import Language.DifferentialDatalog.Syntax
+import Language.DifferentialDatalog.NS
+import Language.DifferentialDatalog.Expr
+import {-# SOURCE #-} Language.DifferentialDatalog.Rule
+import Language.DifferentialDatalog.DatalogProgram
+
+-- | Rules that contain given relation in their heads.
+relRules :: DatalogProgram -> String -> [Rule]
+relRules d rname = filter ((== rname) . atomRelation . head . ruleLHS)
+                   $ progRules d
+
+relIsRecursive :: DatalogProgram -> String -> Bool
+relIsRecursive d rel =
+    any (\(from, to) -> elem from scc && elem to scc) $ G.edges g
+    where
+    g = progDependencyGraph d
+    nd = fst $ fromJust $ find ((== rel) . snd) $ G.labNodes g
+    scc = fromJust $ find (elem nd) $ G.scc g
+    
+exprContainsPHolders :: Expr -> Bool
+exprContainsPHolders e =
+    exprCollect (\case
+                  EPHolder _ -> True
+                  _          -> False)
+                (||) e
+
+-- | Relation only contains records with weight 1 by construction and does not require
+-- distinct() or distinct_total() to convert it to that form.
+relIsDistinctByConstruction :: DatalogProgram -> Relation -> Bool
+-- distinctness is enforced on input relations
+relIsDistinctByConstruction _ Relation{relRole = RelInput, ..}  = True
+-- recursive collection are distinct in differential dataflow 
+relIsDistinctByConstruction d rel | relIsRecursive d (name rel) = True
+relIsDistinctByConstruction d rel 
+    | -- There's only one rule for this relation
+     length rules == 1 && length heads == 1 &&
+     -- The first atom in the body of the rule is a distinct relation and does not contain wildcards
+     length (ruleRHS rule) >= 1 && relIsDistinct d baserel && (not $ exprContainsPHolders $ atomVal atom1) &&
+     -- The head of the rule contains all the variables from the first atom
+     (null $ (nub $ atomVars $ atomVal atom1) \\ (nub $ atomVars $ atomVal head_atom)) &&
+     -- The rule only contains clauses that filter the collection
+     all (\case
+           RHSLiteral True a -> relIsDistinct d (getRelation d $ atomRelation a) &&
+                                (not $ exprContainsPHolders $ atomVal a) &&
+                                (null $ (nub $ atomVars $ atomVal a) \\ (nub $ atomVars $ atomVal head_atom))
+           RHSCondition{}    -> True
+           _                 -> False)
+         (tail $ ruleRHS rule)
+    = True
+    where
+    rules = relRules d $ name rel
+    [rule] = rules
+    heads = filter (\lhs -> atomRelation lhs == name rel) $ ruleLHS rule
+    [head_atom] = heads
+    RHSLiteral _ atom1 = head $ ruleRHS rule
+    baserel = getRelation d $ atomRelation atom1
+relIsDistinctByConstruction _ _ = False
+
+-- | Relation is either distinct by construction or if it is an output relation, in which
+-- case we will explicitly enforce distinctness
+relIsDistinct :: DatalogProgram -> Relation -> Bool
+relIsDistinct d rel = relIsDistinctByConstruction d rel || (relRole rel == RelOutput)


### PR DESCRIPTION
`distinct_total` has a cost of creating an extra arrangement of the collection being distinct'd

Don't call `distinct_total` for output relations that are guaranteed to already be distinct:
- input relations
- recursive relations
- relations that are just a filtering of distinct relations