### PR TITLE
Generate binary ddlog distribution using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ cache:
         - .stack-work
 
 env:
+   - TEST_SUITE='-p tutorial' BUILD_BINARY=1
    - TEST_SUITE='-p souffle'
-   - TEST_SUITE='-p tutorial'
    - TEST_SUITE='-p simple'
    - TEST_SUITE='-p path'
    - TEST_SUITE='-p ovn'
@@ -64,7 +64,26 @@ script:
 #- DDLOG_TEST_PROGRESS=1 stack --no-terminal test --haddock --no-haddock-deps
 - DDLOG_TEST_PROGRESS=1 stack --no-terminal test --ta "$TEST_SUITE"  --haddock --no-haddock-deps
 
-after_success:
- - |
-   # Build and ship binary
-   ./.travis/attach-binary.sh
+before_deploy:
+    # add date and OS name to the tag
+    - export DIST_NAME=ddlog-$TRAVIS_TAG-$(date +'%Y%m%d%H%M%S')-$TRAVIS_OS_NAME
+    #- git tag $TRAVIS_TAG
+    # copy distribution files to a separate directory
+    - stack install --no-terminal
+    - export DIST_DIR=ddlog
+    - mkdir -p $DIST_DIR/bin
+    - export BIN="$(stack path --local-install-root)/bin/ddlog"
+    - cp "$BIN" "$DIST_DIR/bin/"
+    - cp -r lib "$DIST_DIR/"
+    - cp -r java "$DIST_DIR/"
+    - tar -czf "$DIST_NAME.tar.gz" "$DIST_DIR"
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file: "$DIST_NAME.tar.gz"
+  skip_cleanup: true
+  draft: true
+  on:
+    tags: true
+    condition: $BUILD_BINARY = 1

--- a/.travis/attach-binary.sh
+++ b/.travis/attach-binary.sh
@@ -1,24 +1,32 @@
 #!/bin/sh
 set -o errexit -o verbose
 
+OWNER=ryzhyk
+REPO=ddlog
+LIBS=./lib
+JAVA_FILES=./java
+
 if test ! "$BUILD_BINARY" || test ! "$TRAVIS_TAG"
 then
   echo 'This is not a release build.'
+  exit 1
 elif test ! "$GITHUB_TOKEN"
 then
   echo 'The GITHUB_TOKEN environment variable is not set!'
-  exit 1
+  exit 2
 else
   echo "Building binary for $TRAVIS_OS_NAME to $TRAVIS_TAG..."
   stack build --ghc-options -O2 --pedantic
   echo "Attaching binary for $TRAVIS_OS_NAME to $TRAVIS_TAG..."
-  OWNER="$(echo "$TRAVIS_REPO_SLUG" | cut -f1 -d/)"
-  REPO="$(echo "$TRAVIS_REPO_SLUG" | cut -f2 -d/)"
-  BIN="$(stack path --local-install-root)/bin/$REPO"
+  #OWNER="$(echo "$TRAVIS_REPO_SLUG" | cut -f1 -d/)"
+  DIST_DIR=./$REPO
+  mkdir -p "$DIST_DIR/bin"
+  BIN="$(stack path --local-install-root)/bin/ddlog"
   BUNDLE_NAME="$REPO-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz"
-  cp "$BIN" "./$REPO"
-  chmod +x "./$REPO"
-  tar -czf "$BUNDLE_NAME" "$REPO"
+  cp "$BIN" "$DIST_DIR/bin/"
+  cp -r $LIBS "$DIST_DIR/"
+  cp -r $JAVA_FILES "$DIST_DIR/"
+  tar -czf "$BUNDLE_NAME" "$DIST_DIR"
   echo "SHA256:"
   shasum -a 256 "$BUNDLE_NAME"
   ghr -t "$GITHUB_TOKEN" -u "$OWNER" -r "$REPO" --replace "$(git describe --tags)" "$BUNDLE_NAME"

--- a/java/test/span.sh
+++ b/java/test/span.sh
@@ -3,8 +3,6 @@
 
 set -ex
 
-#stack test --ta '-p span_uuid'
-
 # Compile the span_uuid.dl DDlog program
 ddlog -i ../../test/datalog_tests/span_uuid.dl -L../../lib
 # Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a and .so

--- a/package.yaml
+++ b/package.yaml
@@ -43,12 +43,21 @@ executables:
   ddlog:
     main:                Main.hs
     source-dirs:         app
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
-    - -optl-static
-    - -optl-pthread
+    # Mac OS does not support statically linked executables.
+    when:
+    - condition: os(linux)
+      then:
+          ghc-options:
+              - -threaded
+              - -rtsopts
+              - -with-rtsopts=-N
+              - -optl-static
+              - -optl-pthread
+      else:
+          ghc-options:
+              - -threaded
+              - -rtsopts
+              - -with-rtsopts=-N
     dependencies:
     - differential-datalog
     - filepath

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,9 @@ dependencies:
 
 library:
   source-dirs: src
+  ghc-options:
+  - -optl-static
+  - -optl-pthread
 executables:
   ddlog:
     main:                Main.hs
@@ -44,6 +47,8 @@ executables:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -optl-static
+    - -optl-pthread
     dependencies:
     - differential-datalog
     - filepath


### PR DESCRIPTION
- Statically link ddlog executable on Linux to eliminate shared library dependencies
- Configure travis to package ddlog executable and libraries and upload them as github releases on each tagged commit.