### PR TITLE
Fix escaping of Unicode characters that would break parsing.

### DIFF
--- a/test/souffle/convert.py
+++ b/test/souffle/convert.py
@@ -122,7 +122,7 @@ def process_input(inputdecl, files, preprocess):
     #global total
     for line in data:
         fields = line.rstrip('\n').split(separator)
-        fields = map(lambda a: json.dumps(a), fields)
+        fields = map(lambda a: json.dumps(a, ensure_ascii = False), fields)
         files.outputData("insert " + relationname + "(" + ", ".join(fields) + ")", ",")
         #counter = counter + 1
         #total = total + 1


### PR DESCRIPTION
In the Souffle converter, Unicode characters in strings were being escaped as '\uXXXX' sequences in ASCII. This would break the parser during `insert`. This PR keeps the original Unicode characters in place, so that parsing succeeds.