### PR TITLE
Record and replay feature for DDlog

### DIFF
--- a/doc/testing/testing.md
+++ b/doc/testing/testing.md
@@ -1,13 +1,10 @@
 # Creating Datalog Tests
 
-**Thank you for contributing to the differential datalog project!**
+**Thank you for contributing to the DDlog project!**
 
-Follow these steps, detailed below, to create a datalog test.  Note 
-that this testing method is primarily suitable for testing correctness 
-of the datalog engine.  It is not suitable for performance or memory 
-testing, which requires feeding a large number of records to datalog.
+Follow these steps, detailed below, to create a DDlog test.
 
-1. Write a test datalog program
+1. Write a test DDlog program
 1. Create test workload
 1. Create a pull request
 
@@ -15,7 +12,7 @@ testing, which requires feeding a large number of records to datalog.
 
 Test files are located in the `test/datalog_tests` directory.  The
 test script will automatically test all files with `*.dl`
-extension.  
+extension.
 
 1. Create a file named `test/datalog_tests/<test>.dl`, where `<test>` is
    the name of your test.
@@ -29,7 +26,7 @@ this means that the datalog compiler produced invalid Rust code.  Please
 *Note: compilation will take a minute or two the first time as cargo pulls and compiles Rust dependencies*.
 Once compilation succeeds, it will create
 `test/datalog_test/<test>.ast` file and a golden test file `test/datalog_test/<test>.ast.expected`.
-Remove this file whenever you change the datalog program to re-generate it.  
+Remove this file whenever you change the datalog program to re-generate it.
 
 ### Example datalog program `path.dl`
 
@@ -57,8 +54,8 @@ outputs.
 1. Run `stack test` again.  This should create a file named
    `test/datalog_tests/<test>.dump` containing the output of all `dump` and `echo` commands in the script
    and `test/datalog_tests/<test>.dump.expected`.
-1. Inspect the dump file; make sure that the output of the tool is correct. If it's not, 
-   please [submit a bug report](https://github.com/ryzhyk/differential-datalog/issues) 
+1. Inspect the dump file; make sure that the output of the tool is correct. If it's not,
+   please [submit a bug report](https://github.com/ryzhyk/differential-datalog/issues)
    including `.dl` and `.dat` files.
 1. Make sure that you delete the `.expected` file whenever the datalog
    program or the test workload changed; otherwise the test will fail.
@@ -81,7 +78,10 @@ outputs.
 |                                | insert Rel2(.x=10, .y=Constructor{.f1="foo", .f2=true}); | type constructor arguments can also be passed by name          |
 | `delete <record>;`             | delete Rel1(1,true,"foo");                       | delete record from Rel1 (using argument syntax identical to `insert`)  |
 | `delete_key <relation> <key>;` | delete Rel1 1;                                   | delete record by key; only valid for relations with primary key        |
+| `modify <relation> <key> <- <record>;` | modify Rel1 1 <- Rel1{.f1 = 5};          | modify record; `<record>` specifies just the fields to be modified; only valid for relations with primary key        |
 | comma-separated updates        | insert Foo(1), delete Bar("buzz");               | a sequence of insert and delete commands can be applied in one update  |
+| `profile`|                     |                                                  | print CPU and memory profile of the DDlog program                      |
+| `profile cpu "on"|"off"`|      |                                                  | controls the recording of differential operator runtimes; set to "on" to enable the construction of the programs CPU profile (default: "off") |
 | `exit;`                        |                                                  | terminates execution                                                   |
 
 **Note**: Placing a semicolon after an `insert` or `delete` operation tells DDlog to apply the

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -127,7 +127,7 @@ extern ddlog_prog ddlog_run(unsigned int workers,
  * functions in this file in a DDlog command file that can later be replayed
  * throught the CLI interface.
  *
- * `fd` - file descriptor.  Passing 0 in this argument instructs DDlog to stop
+ * `fd` - file descriptor.  Passing -1 in this argument instructs DDlog to stop
  * recording. The caller is responsible for opening and closing the file.  They
  * can inject additional commands, e.g., `echo` to the file.
  */

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -121,6 +121,19 @@ extern ddlog_prog ddlog_run(unsigned int workers,
 			    void (*print_err_msg)(const char *msg));
 
 /*
+ * Record commands issued to DDlog via this API in a file.
+ *
+ * This is a debugging feature used to record DDlog commands issued through
+ * functions in this file in a DDlog command file that can later be replayed
+ * throught the CLI interface.
+ *
+ * `fd` - file descriptor.  Passing 0 in this argument instructs DDlog to stop
+ * recording. The caller is responsible for opening and closing the file.  They
+ * can inject additional commands, e.g., `echo` to the file.
+ */
+extern int ddlog_record_commands(ddlog_prog hprog, int fd);
+
+/*
  * Stops the program; deallocates all resources, invalidates the handle.
  *
  * All concurrent calls using the handle must complete before calling this
@@ -254,6 +267,17 @@ extern int ddlog_dump_table(ddlog_prog prog, table_id table,
 /***********************************************************************
  * Profiling
  ***********************************************************************/
+
+/*
+ * Controls recording of differential operator runtimes.  When enabled,
+ * DDlog records each activation of every operator and prints the
+ * per-operator CPU usage summary in the profile.  When disabled, the
+ * recording stops, but the previously accumulated profile is preserved.
+ *
+ * Recording CPU events can be expensive in large dataflows and is
+ * therefore disabled by default.
+ */
+extern int ddlog_enable_cpu_profiling(ddlog_prog prog, bool enable);
 
 /*
  * Returns DDlog program runtime profile as a C string.

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -79,9 +79,9 @@ impl fmt::Display for Record {
                 let len = recs.len();
                 for (i, (fname, v)) in recs.iter().enumerate() {
                     if i == len - 1 {
-                        write!(f, "{}: {}", fname, v)?;
+                        write!(f, ".{} = {}", fname, v)?;
                     } else {
-                        write!(f, "{}: {}, ", fname, v)?;
+                        write!(f, ".{} = {}, ", fname, v)?;
                     }
                 };
                 write!(f, "}}")

--- a/rust/template/lib.rs
+++ b/rust/template/lib.rs
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn ddlog_record_commands(prog: *const HDDlog, fd: unix::io
             /* Swap out the old file and convert it into FD to prevent
              * the file from closing on destruction (it is the caller's
              * responsibility to close the file when they're done with it). */
-            let mut old_file = if fd == 0 {
+            let mut old_file = if fd == -1 {
                 None
             } else {
                 Some(sync::Mutex::new(fs::File::from_raw_fd(fd)))
@@ -259,7 +259,7 @@ pub unsafe extern "C" fn ddlog_stop(prog: *const HDDlog) -> raw::c_int
         return -1;
     };
     /* Prevents closing of the old descriptor. */
-    ddlog_record_commands(prog, 0);
+    ddlog_record_commands(prog, -1);
 
     let prog = sync::Arc::from_raw(prog);
     match sync::Arc::try_unwrap(prog) {

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -70,9 +70,13 @@ fn handle_cmd(db: &Arc<Mutex<ValMap>>, p: &mut RunningProgram<Value>, upds: &mut
             println!("Timestamp: {}", precise_time_ns());
             Ok(())
         },
-        Command::Profile => {
+        Command::Profile(None) => {
             let profile = (*p.profile.lock().unwrap()).clone();
             println!("Profile:\n{}", profile);
+            Ok(())
+        },
+        Command::Profile(Some(ProfileCmd::CPU(enable))) => {
+            p.enable_cpu_profiling(enable);
             Ok(())
         },
         Command::Dump(None) => {

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -719,6 +719,7 @@ mkValueFromRecord d@DatalogProgram{..} =
     mkOutputRelname2Id d                                                                            $$
     mkInputRelname2Id d                                                                             $$
     mkRelId2Relations d                                                                             $$
+    mkRelId2Name d                                                                                  $$
     "pub fn relval_from_record(rel: Relations, rec: &record::Record) -> Result<Value, String> {"    $$
     "    match rel {"                                                                               $$
     (nest' $ nest' $ vcat $ punctuate comma entries)                                                $$
@@ -788,7 +789,7 @@ mkInputRelname2Id d =
 
 
 
--- Convert string to RelId
+-- Convert string to enum Relations
 mkRelId2Relations :: DatalogProgram -> Doc
 mkRelId2Relations d =
     "pub fn relid2rel(rid: RelId) -> Option<Relations> {"   $$
@@ -801,6 +802,19 @@ mkRelId2Relations d =
     entries = mapIdx mkrel $ M.elems $ progRelations d
     mkrel :: Relation -> Int -> Doc
     mkrel rel i = pp i <+> "=> Some(Relations::" <> rname (name rel) <> "),"
+
+mkRelId2Name :: DatalogProgram -> Doc
+mkRelId2Name d =
+    "pub fn relid2name(rid: RelId) -> Option<&'static str> {" $$
+    "   match rid {"                                          $$
+    (nest' $ nest' $ vcat $ entries)                          $$
+    "       _  => None"                                       $$
+    "   }"                                                    $$
+    "}"
+    where
+    entries = mapIdx mkrel $ M.elems $ progRelations d
+    mkrel :: Relation -> Int -> Doc
+    mkrel rel i = pp i <+> "=> Some(&\"" <> pp (name rel) <> "\"),"
 
 mkFunc :: DatalogProgram -> Function -> Doc
 mkFunc d f@Function{..} | isJust funcDef =

--- a/src/Language/DifferentialDatalog/OVSDB/Compile.hs
+++ b/src/Language/DifferentialDatalog/OVSDB/Compile.hs
@@ -96,16 +96,16 @@ The following diagram illustrates dependencies among the various kinds of relati
 
 
       (user-defined rules)                                  (user-defined rules)
-Input--------------------> Output---------------->Swizzled------------------------>OutputProxy-------> Delta+ <---------|
-                                                    ^                                   |                               |
-                                                    |                                   |                               |
-                                                    |                                   |                               |
-Realized----------------> UUIDMap <------------------                                   |------------> Delta- <---------|
+Input--------------------> Output---------------->Swizzled------------------------>OutputProxy-------> Delta+ <---------+
+                             |                      ^                                   |                               |
+                             |                      |                                   |                               |
+                             v                      |                                   |                               |
+Realized----------------> UUIDMap <-----------------+                                   |------------> Delta- <---------|
   |                                                                                     |                               |
   |                                                                                     |                               |
-  |                                                                                     |------------> DeltaUpdate <-----
+  |                                                                                     +----------> DeltaUpdate <------|
   |                                                                                                                     |
-  |----------------------------------------------------------------------------------------------------------------------
+  +---------------------------------------------------------------------------------------------------------------------+
 
 -}
 
@@ -461,8 +461,13 @@ mkSwizzleRules t@Table{..} = do
         (nest' $ mkTableName t TableOutput <> "(" <> commaSep outcols <> "),")      $$
         (nest' $ vcommaSep swizzles) <> "."
 
--- UUIDMap(name, Left(uuid)) :- Output(name, key), Realized(uuid, key).
--- UUIDMap(name, Right(name)) :- Output(name, key), not Realized(_, key).
+-- UUIDMap_Meter_Band("", Right{""}).
+-- UUIDMap_Meter_Band(__name, Left{__uuid}) :-
+--     Out_Meter_Band(__name, action, rate, burst_size),
+--     Meter_Band(__uuid, action, rate, burst_size).
+-- UUIDMap_Meter_Band(__name, Right{__name}) :-
+--    Out_Meter_Band(__name, action, rate, burst_size),
+--    not Meter_Band(_, action, rate, burst_size).
 mkUUIDMapRules :: (?schema::OVSDBSchema, ?outputs::[(String, [String])], ?with_oproxies::[String]) => Table -> Maybe [String] -> Doc
 mkUUIDMapRules t@Table{..} mkeys =
     if referenced


### PR DESCRIPTION
It can be hard to debug and profile DDlog when it's running as a library
in a bigger program.  For instance, there is typically no easy way to modify
inputs to DDlog.

This commit adds the ability to record DDlog commands in a dat file that
can later be replayed against the standalone DDlog executable (`prog_cli`).
To enable this feature, the client calls the new `ddlog_record_commands`
method, supplying an open file descriptor as argument.  DDlog will write
command stream to this file.

This commit also introduces command syntax for the `modify` operation,
which is necessary to ensure that all commands supported via the API
also have command-line equivalents.

Finally, two new commands (and matching API functions) were introduced:
`profile cpu on`, `profile cpu off` enable and disable CPU profiling
respectively.  It turns out that intercepting all operator activations
is expensive in large dataflows, so it makes sense to only do it for
selected program sections and only when necessary.