### PR TITLE
Support for meta-attributes

### DIFF
--- a/doc/language_reference/language_reference.md
+++ b/doc/language_reference/language_reference.md
@@ -39,16 +39,24 @@ is defined in the local scope).
 
 A Datalog program is a list of type definitions, functions, relations, and rules.
 The ordering of declarations does not matter, e.g., a type can be used
-before being defined.
+before being defined.  Declarations can be optionally annotated by
+meta-attributes.
 
 ```EBNF
-datalog ::= decl*
+datalog ::= annotated_decl*
+
+annotated_decl ::= [attributes] decl
 
 decl ::= import
        | typedef
        | function
        | relation
        | rule
+
+attributes ::= "#[" attribute ["," attribute]* "]"
+
+attribute ::= name "=" expr
+
 ```
 
 ### Constraints on top-level declarations
@@ -722,4 +730,16 @@ insertStatement ::= rel_name "(" expression ( "," expression )* ")"
 blockStatement ::= "{" statement ( ";" statement )* "}"
 
 emptyStatement ::= "skip"
+```
+
+# Supported meta-attributes
+
+Only one attribute is supported at the moment, namely the `size` attribute,
+applicable to `extern type` declarations.  It specifies the size of the
+corresponding Rust data type in bytes and serves as a hint to compiler
+to optimize data structures layout.
+
+```
+#[size=4]
+extern type IObj<'A>
 ```

--- a/lib/intern.dl
+++ b/lib/intern.dl
@@ -6,6 +6,7 @@
  * While this type is defined for any `'A`, interning is only supported for strings.
  * There is simply no way to obtain an interned object of a different type.
  */
+#[size=4]
 extern type IObj<'A>
 
 /* Interned string

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2081,7 +2081,10 @@ typeSize' d (TStruct _ cs) =
     tag_align = maximum $ 1 : map (consAlignment d . consArgs) cs
     tag_size = pad 4 tag_align
 typeSize' d (TTuple _ as) = tupleSize d as
-typeSize' _ TOpaque{}     = 0xffffffff -- be conservative
+typeSize' d TOpaque{..}     =
+    case tdefGetSizeAttr (getType d typeName) of
+         Nothing     -> 0xffffffff -- be conservative
+         Just nbytes -> nbytes
 typeSize' _ t             = error $ "Compiler.typeSize': unexpected type " ++ show t
 
 consSize :: DatalogProgram -> [Field] -> Int
@@ -2110,7 +2113,10 @@ typeAlignment' _ TBit{..} | typeWidth <= 8   = 1
 typeAlignment' d (TStruct _ [cons]) = consAlignment d $ consArgs cons
 typeAlignment' d (TStruct _ cs) = maximum $ 1 : map (consAlignment d . consArgs) cs
 typeAlignment' d (TTuple _ as)  = tupleAlignment d as
-typeAlignment' _ TOpaque{}      = 128 -- be conservative
+typeAlignment' d TOpaque{..}    =
+    case tdefGetSizeAttr (getType d typeName) of
+         Nothing     -> 128 -- be conservative
+         Just nbytes -> nbytes
 typeAlignment' _ t              = error $ "Compiler.typeSize: unexpected type " ++ show t
 
 consAlignment :: DatalogProgram -> [Field] -> Int

--- a/src/Language/DifferentialDatalog/DatalogProgram.hs
+++ b/src/Language/DifferentialDatalog/DatalogProgram.hs
@@ -104,7 +104,7 @@ progExprMapCtx d fun = runIdentity $ progExprMapCtxM d  (\ctx e -> return $ fun 
 -- | Apply function to all types referenced in the program
 progTypeMapM :: (Monad m) => DatalogProgram -> (Type -> m Type) -> m DatalogProgram
 progTypeMapM d@DatalogProgram{..} fun = do
-    ts <- M.traverseWithKey (\_ (TypeDef p n a t) -> TypeDef p n a <$> mapM (typeMapM fun) t) progTypedefs
+    ts <- M.traverseWithKey (\_ (TypeDef p atrs n a t) -> TypeDef p atrs n a <$> mapM (typeMapM fun) t) progTypedefs
     fs <- M.traverseWithKey (\_ f -> do ret <- typeMapM fun $ funcType f
                                         as  <- mapM (\f -> setType f <$> (typeMapM fun $ typ f)) $ funcArgs f
                                         d   <- mapM (exprTypeMapM fun) $ funcDef f

--- a/test/datalog_tests/constr.fail.ast.expected
+++ b/test/datalog_tests/constr.fail.ast.expected
@@ -1,6 +1,6 @@
 Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 2, column 23):
 unexpected '{'
-expecting "import", "typedef", "extern", "input", "output", "relation", "function", "transformer", variable name, "&", relation name, "apply", "for" or end of input
+expecting "#", "import", "typedef", "extern", "input", "output", "relation", "function", "transformer", variable name, "&", relation name, "apply", "for" or end of input
 
 error: ./test/datalog_tests/constr.fail.dl:4:13-4:29: Multiple definitions of constructor C at the following locations:
   ./test/datalog_tests/constr.fail.dl:4:13-4:29

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -92,6 +92,7 @@ typedef YX = YX{y: bigint, x: bigint}
 typedef YZX = YZX{y: bigint, z: bigint, x: bigint}
 typedef Z = Z{field: bigint}
 typedef ZZ = ZZ{x: bigint, y: R3}
+#[size = 4]
 extern type intern.IObj<'A>
 typedef intern.IString = intern.IObj<string>
 typedef ip_addr_t = IPAddr{b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>}


### PR DESCRIPTION
Meta-attributes annotate top-level DDlog declarations (types, relations,
functions, and rules).  They do not change the semantics of the program,
but affect compilation process.

Only one attribute is supported at the moment, namely the `size` attribute,
applicable to `extern type` declarations.  It specifies the size of the
corresponding Rust data type in bytes:

```
 #[size=4]
 extern type IObj<'A>
```

The compiler uses this attribute to more accurately compute data
structure sizes to avoid boxing small structs.

This reduces the runtime of the souffle benchmark from 11 to 7 seconds
(see #165)