### PR TITLE
Size annotation for `Ref<>`

### DIFF
--- a/lib/std.dl
+++ b/lib/std.dl
@@ -3,6 +3,7 @@
 /*
  * Ref
  */
+#[size=8]
 extern type Ref<'A>
 
 extern function ref_new(x: 'A): Ref<'A>

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -11,6 +11,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -72,6 +72,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -10,6 +10,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -5,6 +5,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/redist.ast.expected
+++ b/test/datalog_tests/redist.ast.expected
@@ -12,6 +12,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -105,6 +105,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/span_string.ast.expected
+++ b/test/datalog_tests/span_string.ast.expected
@@ -12,6 +12,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/span_uuid.ast.expected
+++ b/test/datalog_tests/span_uuid.ast.expected
@@ -12,6 +12,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -57,6 +57,7 @@ typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>


### PR DESCRIPTION
Tell the compiler that `Ref` is only 8 bytes wide and does not need to
be wrapped in a box.