### PR TITLE
Support for user-defined aggregates

### DIFF
--- a/lib/ovsdb.rs
+++ b/lib/ovsdb.rs
@@ -9,42 +9,43 @@ pub fn ovsdb_set_extract_uuids(ids: &std_Set<ovsdb_uuid_or_string_t>) -> std_Set
     std_Set::from_iter(ids.x.iter().map(|x| ovsdb_extract_uuid(x)))
 }
 
-pub fn ovsdb_group2vec_remove_sentinel<G: Group<ovsdb_uuid_or_string_t>+?Sized>(g: &G) -> std_Vec<ovsdb_uuid_or_string_t> {
+pub fn ovsdb_group2vec_remove_sentinel(g: &std_Group<ovsdb_uuid_or_string_t>) -> std_Vec<ovsdb_uuid_or_string_t> {
     let mut res = std_Vec::new();
-    for i in 0..g.size() {
-        match g.ith(i) {
-            std_Either::std_Right{r} => {
-                if r.as_str() != "" { res.push(std_Either::std_Right{r}); };
-            },
-            v => { res.push(v); }
-        }
-    };
-    res
-}
-
-pub fn ovsdb_group2set_remove_sentinel<G: Group<ovsdb_uuid_or_string_t>+?Sized>(g: &G) -> std_Set<ovsdb_uuid_or_string_t> {
-    let mut res = std_Set::new();
-    for i in 0..g.size() {
-        match g.ith(i) {
-            std_Either::std_Right{r} => {
-                if r.as_str() != "" { res.insert(std_Either::std_Right{r}); };
-            },
-            v => { res.insert(v); }
-        }
-    };
-    res
-}
-
-
-pub fn ovsdb_group2map_remove_sentinel<K: Ord, G:Group<(K,ovsdb_uuid_or_string_t)>+?Sized>(g: &G) -> std_Map<K,ovsdb_uuid_or_string_t> {
-    let mut res = std_Map::new();
-    for i in 0..g.size() {
-        let (k,v) = g.ith(i);
+    for v in g.iter() {
         match v {
             std_Either::std_Right{r} => {
-                if r.as_str() != "" { res.insert(k, std_Either::std_Right{r}); };
+                if r.as_str() != "" { res.push(std_Either::std_Right{r: r.clone()}); };
             },
-            _ => { res.insert(k, v); }
+            v => { res.push(v.clone()); }
+        }
+    };
+    res
+}
+
+pub fn ovsdb_group2set_remove_sentinel(g: &std_Group<ovsdb_uuid_or_string_t>) -> std_Set<ovsdb_uuid_or_string_t> {
+    let mut res = std_Set::new();
+    for v in g.iter() {
+        match v {
+            std_Either::std_Right{r} => {
+                if r.as_str() != "" { res.insert(std_Either::std_Right{r: r.clone()}); };
+            },
+            v => { res.insert(v.clone()); }
+        }
+    };
+    res
+}
+
+
+pub fn ovsdb_group2map_remove_sentinel<K: Ord + Clone>(g: &std_Group<(K,ovsdb_uuid_or_string_t)>) -> std_Map<K,ovsdb_uuid_or_string_t>
+where (K, ovsdb_uuid_or_string_t): FromValue
+{
+    let mut res = std_Map::new();
+    for (k,v) in g.iter() {
+        match v {
+            std_Either::std_Right{r} => {
+                if r.as_str() != "" { res.insert((*k).clone(), std_Either::std_Right{r: r.clone()}); };
+            },
+            _ => { res.insert((*k).clone(), v.clone()); }
         }
     };
     res

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -77,28 +77,49 @@ extern function str_to_lower(s: string): string
 extern function hash64(x: 'X): bit<64>
 extern function hash128(x: 'X): bit<128>
 
+/* The `Group` type is used exclusively in aggregation operations.  It
+ * represents a non-empty list of objects sorted in ascending order.
+ */ 
+extern type Group<'A>
+
 /*
  * Standard aggregates
  */
 
-extern type Group<'A>
+/* Returns the number of elements in the group, which is guaranteed
+ * to be >0. */
+extern function group_count(g: Group<'A>): bit<64>
 
-extern function count(g: Group<'A>): bit<64>
+/* Returns the first element of the group.
+ * It always exists, as aggregation cannot return an empty group. */
+extern function group_first(g: Group<'A>): 'A
+
+/* Returns `n`th element of the group if the group is large enough
+ * or `None` otherwise.
+ */
+extern function group_nth(g: Group<'A>, n: bit<64>): Option<'A>
+
 extern function group2set(g: Group<'A>): Set<'A>
 extern function group2vec(g: Group<'A>): Vec<'A>
 extern function group2map(g: Group<('K,'V)>): Map<'K,'V>
-extern function group_unzip(g: Group<('X,'Y)>): (Vec<'X>, Vec<'Y>)
 extern function group_sum(g: Group<'A>): 'A
+
+function group_unzip(g: Group<('X,'Y)>): (Vec<'X>, Vec<'Y>) = {
+    var xs: Vec<'X> = vec_empty();
+    var ys: Vec<'Y> = vec_empty();
+    for (v in g) {
+        (var x, var y) = v;
+        vec_push(xs, x);
+        vec_push(ys, y)
+    };
+    (xs,ys)
+}
 
 extern function group_set_unions(g: Group<Set<'A>>): Set<'A>
 
 /* Optimized version of group_set_unions that, when the group consits of
  * a single set, simply returns the reference to this set. */
 extern function group_setref_unions(g: Group<Ref<Set<'A>>>): Ref<Set<'A>>
-
-/* Returns the first element of the group.
- * It always exists, as aggregation cannot return an empty group. */
-extern function group_first(g: Group<'A>): 'A
 
 /* Smallest and largest group elements. */
 extern function group_min(g: Group<'A>): 'A

--- a/rust/template/build.rs
+++ b/rust/template/build.rs
@@ -19,7 +19,7 @@ fn main() {
     let target_dir = format!("{}/target/{}", topdir, profile);
     let libs_dir = format!("{}/.libs", target_dir);
     let new_lib_path = PathBuf::from(format!("{}/{}.a", libs_dir, lib));
-    fs::remove_file(&new_lib_path);
+    let _ = fs::remove_file(&new_lib_path);
     /* End: fixup */
 
     libtool::generate_convenience_lib(lib).unwrap();

--- a/rust/template/lib.rs
+++ b/rust/template/lib.rs
@@ -557,3 +557,7 @@ pub extern "C" fn ddlog_string_free(s: *mut raw::c_char)
     };
     unsafe { ffi::CString::from_raw(s); }
 }
+
+pub trait FromValue {
+    fn from_value(&Value) -> &Self;
+}

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -20,18 +20,27 @@ function fmain (a1: foolib.lib.Rlib): foolib.ns1.m1.R1 =
 function foolib.ns1.m1.fM1 (a1: foolib.ns1.m1.T1): foolib.ns1.m1.R1 =
     foolib.ns1.m1.R1{.f1=foolib.ns1.m2.T2{.f1=a1.f1}}
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -87,18 +87,27 @@ extern function ip_address_and_port_from_lb_key (key: string): ip_port_t
 extern function ip_parse (str: string): std.Option<ip_addr_t>
 extern function ipv6_string_mapped (addr: ip6_addr_t): string
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -15,18 +15,27 @@ extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -10,18 +10,27 @@ extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string

--- a/test/datalog_tests/redist.ast.expected
+++ b/test/datalog_tests/redist.ast.expected
@@ -23,18 +23,27 @@ function edge_child (e: BiEdge): entid_t =
 function edge_parent (e: BiEdge): entid_t =
     e.parent
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -309,18 +309,27 @@ function souffle_lib.to_number (s: intern.IString): bit<64> =
 function souffle_lib.to_string (n: bit<32>): intern.IString =
     intern.string_intern(std.__builtin_2string(n))
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
@@ -628,7 +637,7 @@ Strings(.s="word1 word2").
 Strings(.s="line1\nline2").
 Rel3(.x=x, .y=y, .z=z) :- Rel1(.x=x, .y=y), Rel2(.x=x, .z=z).
 Rel4(.x=x, .y=y, .b=b) :- Rel1(.x=x, .y=y), Rel2(.x=x, .z=Option1{.f1=_, .f2=IP4{.ip4=_}, .f3=(b, "buzz")}).
-Aggregate1(.x=x, .cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((x), std.count(y)).
+Aggregate1(.x=x, .cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((x), std.group_count(y)).
 Aggregate2(.x=x, .set=set) :- AggregateMe1(.x=x, .y=y), var set = Aggregate((x), std.group2set(y)).
 Aggregate3(.x=x, .vec=vec) :- AggregateMe1(.x=x, .y=y), var vec = Aggregate((x), std.group2vec(y)).
 Aggregate4(.x=x, .map=map) :- AggregateMe1(.x=x, .y=y), var map = Aggregate((x), std.group2map((x, y))).

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -614,7 +614,7 @@ Rel4(x,y,b) :- Rel1(x,y),
 input relation AggregateMe1(x: string, y: string)
 
 output relation Aggregate1(x: string, cnt: bit<64>)
-Aggregate1(x, cnt) :- AggregateMe1(x,y), var cnt = Aggregate((x), count(y)).
+Aggregate1(x, cnt) :- AggregateMe1(x,y), var cnt = Aggregate((x), group_count(y)).
 
 output relation Aggregate2(x: string, set: Set<string>)
 Aggregate2(x, set) :- AggregateMe1(x,y), var set = Aggregate((x), group2set(y)).

--- a/test/datalog_tests/span_string.ast.expected
+++ b/test/datalog_tests/span_string.ast.expected
@@ -19,18 +19,27 @@ extern type std.Vec<'A>
 typedef tnid_t = uuid_t
 typedef uuid_t = string
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string

--- a/test/datalog_tests/span_uuid.ast.expected
+++ b/test/datalog_tests/span_uuid.ast.expected
@@ -19,18 +19,27 @@ extern type std.Vec<'A>
 typedef tnid_t = uuid_t
 typedef uuid_t = std.Ref<bit<128>>
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -76,6 +76,19 @@ function addr_port (ip: ip_addr_t, proto: string, preferred_port: bit<16>): stri
      ((("" ++ ip_addr_t2string(ip)) ++ ":") ++ std.__builtin_2string(port)))
 function addr_to_tuple (addr: ip4_addr_t): (bit<8>, bit<8>, bit<8>, bit<8>) =
     (addr[31:24], addr[23:16], addr[15:8], addr[7:0])
+function best_vendor (g: std.Group<(string, bit<64>)>): (string, bit<64>) =
+    (var min_vendor = "";
+     ((var min_price: bit<64>) = 64'd18446744073709551615;
+      (for (vendor_price in g) {
+           ((var vendor, var price) = vendor_price;
+            if (price < min_price) {
+                (min_vendor = vendor;
+                 min_price = price)
+            } else {
+                  ()
+              })
+       };
+       (min_vendor, min_price))))
 function ip_addr_t2string (ip: ip_addr_t): string =
     ((((((("" ++ std.__builtin_2string(ip.addr[31:24])) ++ ".") ++ std.__builtin_2string(ip.addr[23:16])) ++ ".") ++ std.__builtin_2string(ip.addr[15:8])) ++ ".") ++ std.__builtin_2string(ip.addr[7:0]))
 function ip_from_bytes (b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>): ip_addr_t =
@@ -114,18 +127,27 @@ extern function split (s: string, sep: string): std.Vec<string>
 function split_ip_list (x: string): std.Vec<string> =
     split(x, " ")
 extern function std.__builtin_2string (x: 'X): string
-extern function std.count (g: std.Group<'A>): bit<64>
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
 extern function std.group2set (g: std.Group<'A>): std.Set<'A>
 extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
 extern function std.group_first (g: std.Group<'A>): 'A
 extern function std.group_max (g: std.Group<'A>): 'A
 extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
 extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
 extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
 extern function std.group_sum (g: std.Group<'A>): 'A
-extern function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>)
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
 extern function std.hash128 (x: 'X): bit<128>
 extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
@@ -251,18 +273,7 @@ Sum(.x=x, .y=y, .sum=(x + y)),
 Product(.x=x, .y=y, .prod=(x * y)) :- X(.x=x), X(.x=y).
 BestPrice(.item=item, .price=best_price) :- Price(.item=item, .vendor=_, .price=price), var best_price = Aggregate((item), std.group_min(price)).
 WorstPrice(.item=item, .price=best_price) :- Price(.item=item, .vendor=_, .price=price), var best_price = Aggregate((item), std.group_max(price)).
-BestVendor(.item=item, .vendor=best_vendor, .price=best_price) :- Price(.item=item, .vendor=vendor, .price=price), var vendor_price_vec = Aggregate((item), std.group2vec((vendor, price))), (var best_vendor, var best_price) = (var min_vendor = "";
-                                                                                                                                                                                                                                  (var min_price = (64'd18446744073709551615: bit<64>);
-                                                                                                                                                                                                                                   (for (vendor_price in vendor_price_vec) {
-                                                                                                                                                                                                                                        ((var vendor, var price) = vendor_price;
-                                                                                                                                                                                                                                         if (price < min_price) {
-                                                                                                                                                                                                                                             (min_vendor = vendor;
-                                                                                                                                                                                                                                              min_price = price)
-                                                                                                                                                                                                                                         } else {
-                                                                                                                                                                                                                                               ()
-                                                                                                                                                                                                                                           })
-                                                                                                                                                                                                                                    };
-                                                                                                                                                                                                                                    (min_vendor, min_price)))).
+BestVendor(.item=item, .vendor=best_vendor, .price=best_price) :- Price(.item=item, .vendor=vendor, .price=price), var best_vendor_price = Aggregate((item), best_vendor((vendor, price))), (var best_vendor, var best_price) = best_vendor_price.
 TCPDstPort(.port=port) :- Packet(.pkt=EthPacket{.src=_, .dst=_, .payload=EthIP4{.ip4=IP4Pkt{.ttl=_, .src=_, .dst=_, .payload=IPTCP{.tcp=TCPPkt{.src=_, .dst=port, .flags=_}}}}}).
 TCPDstPort(.port=port) :- Packet(.pkt=EthPacket{.src=_, .dst=_, .payload=EthIP6{.ip6=IP6Pkt{.ttl=_, .src=_, .dst=_, .payload=IPTCP{.tcp=TCPPkt{.src=_, .dst=port, .flags=_}}}}}).
 UDPDstPort(.port=port) :- Packet(.pkt=pkt), var port = pkt_udp_port(pkt), (port != 16'd0).

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -226,21 +226,25 @@ WorstPrice(item, best_price) :-
 
 output relation BestVendor(item: string, vendor: string, price: bit<64>)
 
+// TODO: this can really benefit from the ability to access tuple fields by number
+function best_vendor(g: Group<(string, bit<64>)>): (string, bit<64>) =
+{
+    var min_vendor = "";
+    var min_price: bit<64> = 'hffffffffffffffff;
+    for (vendor_price in g) {
+        (var vendor, var price) = vendor_price;
+        if (price < min_price) {
+            min_vendor = vendor;
+            min_price = price
+        } else ()
+    };
+    (min_vendor, min_price)
+}
+
 BestVendor(item, best_vendor, best_price) :-
     Price(item, vendor, price),
-    var vendor_price_vec = Aggregate((item), group2vec((vendor, price))),
-    (var best_vendor, var best_price) = {
-        var min_vendor = "";
-        var min_price = 'hffffffffffffffff: bit<64>;
-        for (vendor_price in vendor_price_vec) {
-            (var vendor, var price) = vendor_price;
-            if (price < min_price) {
-                min_vendor = vendor;
-                min_price = price
-            } else ()
-        };
-        (min_vendor, min_price)
-    }.
+    var best_vendor_price = Aggregate((item), best_vendor((vendor, price))),
+    (var best_vendor, var best_price) = best_vendor_price.
 
 /*
  * Example: tagged unions


### PR DESCRIPTION
This addresses an important limitation: DDlog used to only support
aggregation functions written in Rust, which would have been a major
roadblock for most users.

With this commit, the `Aggregate` operator allows arbitrary user-defined
functions with the following signature:

```
function f(Group<X>): Y
```

where `X` and `Y` are arbitrary types.  `Group` is an `extern` type,
that can be manipulated using three functions declared in `std.dl`:

```
extern function group_count(g: Group<'A>): bit<64>
extern function group_first(g: Group<'A>): 'A
extern function group_nth(g: Group<'A>, n: bit<64>): Option<'A>
```

In addition, `Group` can be iterated over in a for-loop.