### PR TITLE
Use wrapping arithmetic operations

### DIFF
--- a/rust/template/differential_datalog/uint.rs
+++ b/rust/template/differential_datalog/uint.rs
@@ -29,6 +29,15 @@ impl Uint {
     pub fn from_bigint(v: BigInt) -> Uint {
         Uint{x: v.to_biguint().unwrap()}
     }
+    pub fn from_u8(v: u8) -> Uint {
+        Uint{x: BigUint::from(v)}
+    }
+    pub fn from_u16(v: u16) -> Uint {
+        Uint{x: BigUint::from(v)}
+    }
+    pub fn from_u32(v: u32) -> Uint {
+        Uint{x: BigUint::from(v)}
+    }
     pub fn from_u64(v: u64) -> Uint {
         Uint{x: BigUint::from(v)}
     }
@@ -137,21 +146,22 @@ impl Uint {
 }
 */
 
-impl Shr<usize> for Uint {
+/* DDlog supports 32-bit shifts */
+impl Shr<u32> for Uint {
     type Output = Uint;
 
     #[inline]
-    fn shr(self, rhs: usize) -> Uint {
-        Uint{x: self.x.shr(rhs)}
+    fn shr(self, rhs: u32) -> Uint {
+        Uint{x: self.x.shr(rhs as usize)}
     }
 }
 
-impl Shl<usize> for Uint {
+impl Shl<u32> for Uint {
     type Output = Uint;
 
     #[inline]
-    fn shl(self, rhs: usize) -> Uint {
-        Uint{x: self.x.shl(rhs)}
+    fn shl(self, rhs: u32) -> Uint {
+        Uint{x: self.x.shl(rhs as usize)}
     }
 }
 

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -553,8 +553,8 @@ ctxExpectType d (CtxBinOpR e ctx)                    =
          Impl   -> Just tBool
          Plus   -> tlhs
          Minus  -> tlhs
-         ShiftR -> Nothing
-         ShiftL -> Nothing
+         ShiftR -> Just $ tBit 32
+         ShiftL -> Just $ tBit 32
          Mod    -> tlhs
          Times  -> tlhs
          Div    -> tlhs

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -594,11 +594,11 @@ exprValidate2 d _   (EBinOp p op e1 e2) = do
         Impl   -> do {m; isbool}
         Plus   -> do {m; isint1}
         Minus  -> do {m; isint1}
-        ShiftR -> do {isint1; isint2}
-        ShiftL -> do {isint1; isint2}
-        Mod    -> do {isint1; isint2}
-        Times  -> do {isint1; isint2}
-        Div    -> do {isint1; isint2}
+        ShiftR -> do isint1
+        ShiftL -> do isint1
+        Mod    -> do {m; isint1; isint2}
+        Times  -> do {m; isint1; isint2}
+        Div    -> do {m; isint1; isint2}
         BAnd   -> do {m; isbit1}
         BOr    -> do {m; isbit1}
         BXor   -> do {m; isbit1}


### PR DESCRIPTION
With this commit, arithmetic operations should not crash on overflow.

It also fixes the broken handling of left and right shifts.