### PR TITLE
Multiset semantics for groups.

### DIFF
--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -1443,6 +1443,8 @@ DDlog offers several ways to feed data to a program:
 
 1. From a C or C++ program.
 
+1. From a Java program.
+
 In the following sections, we expand on each method.
 
 #### Specifying ground facts statically in the program source code

--- a/lib/ovsdb.rs
+++ b/lib/ovsdb.rs
@@ -11,7 +11,7 @@ pub fn ovsdb_set_extract_uuids(ids: &std_Set<ovsdb_uuid_or_string_t>) -> std_Set
 
 pub fn ovsdb_group2vec_remove_sentinel(g: &std_Group<ovsdb_uuid_or_string_t>) -> std_Vec<ovsdb_uuid_or_string_t> {
     let mut res = std_Vec::new();
-    for v in g.iter() {
+    for ref v in g.iter() {
         match v {
             std_Either::std_Right{r} => {
                 if r.as_str() != "" { res.push(std_Either::std_Right{r: r.clone()}); };
@@ -24,7 +24,7 @@ pub fn ovsdb_group2vec_remove_sentinel(g: &std_Group<ovsdb_uuid_or_string_t>) ->
 
 pub fn ovsdb_group2set_remove_sentinel(g: &std_Group<ovsdb_uuid_or_string_t>) -> std_Set<ovsdb_uuid_or_string_t> {
     let mut res = std_Set::new();
-    for v in g.iter() {
+    for ref v in g.iter() {
         match v {
             std_Either::std_Right{r} => {
                 if r.as_str() != "" { res.insert(std_Either::std_Right{r: r.clone()}); };
@@ -37,10 +37,9 @@ pub fn ovsdb_group2set_remove_sentinel(g: &std_Group<ovsdb_uuid_or_string_t>) ->
 
 
 pub fn ovsdb_group2map_remove_sentinel<K: Ord + Clone>(g: &std_Group<(K,ovsdb_uuid_or_string_t)>) -> std_Map<K,ovsdb_uuid_or_string_t>
-where (K, ovsdb_uuid_or_string_t): FromValue
 {
     let mut res = std_Map::new();
-    for (k,v) in g.iter() {
+    for (ref k, ref v) in g.iter() {
         match v {
             std_Either::std_Right{r} => {
                 if r.as_str() != "" { res.insert((*k).clone(), std_Either::std_Right{r: r.clone()}); };

--- a/lib/tinyset.rs
+++ b/lib/tinyset.rs
@@ -223,16 +223,15 @@ pub fn std_set_unions<X: u64set::Fits64 + Ord + Clone>(sets: &std_Vec<tinyset_Se
     tinyset_Set64{x: s}
 }
 
-pub fn tinyset_group2set<X: u64set::Fits64 + Ord + FromValue>(g: &std_Group<X>) -> tinyset_Set64<X> {
+pub fn tinyset_group2set<X: u64set::Fits64 + Ord>(g: &std_Group<X>) -> tinyset_Set64<X> {
     let mut res = tinyset_Set64::new();
-    for v in g.iter() {
+    for ref v in g.iter() {
         tinyset_insert(&mut res, v);
     };
     res
 }
 
 pub fn tinyset_group_set_unions<X: u64set::Fits64 + Ord + Clone>(g: &std_Group<tinyset_Set64<X>>) -> tinyset_Set64<X>
-where tinyset_Set64<X>: FromValue
 {
     let mut res = u64set::Set64::new();
     for gr in g.iter() {
@@ -247,7 +246,6 @@ where tinyset_Set64<X>: FromValue
 
 pub fn tinyset_group_setref_unions<X: u64set::Fits64 + Ord + Clone>(g: &std_Group<std_Ref<tinyset_Set64<X>>>)
     -> std_Ref<tinyset_Set64<X>> 
-where std_Ref<tinyset_Set64<X>>: FromValue
 {
     if std_group_count(g) == 1 {
         std_group_first(g)

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -956,6 +956,7 @@ fn test_map(nthreads: usize) {
                         afun: &(gfun3 as ArrangeFunc<Value>),
                         next: Box::new(XFormArrangement::Aggregate{
                             description: "2.aggregate".to_string(),
+                            ffun: None,
                             aggfun: &(agfun3 as AggFunc<Value>),
                             next: Box::new(None)
                         })
@@ -984,6 +985,7 @@ fn test_map(nthreads: usize) {
                         afun: &(gfun4 as ArrangeFunc<Value>),
                         next: Box::new(XFormArrangement::Aggregate {
                             description: "2.aggregate".to_string(),
+                            ffun: None,
                             aggfun: &(agfun4 as AggFunc<Value>),
                             next: Box::new(None)
                         })

--- a/rust/template/lib.rs
+++ b/rust/template/lib.rs
@@ -557,7 +557,3 @@ pub extern "C" fn ddlog_string_free(s: *mut raw::c_char)
     };
     unsafe { ffi::CString::from_raw(s); }
 }
-
-pub trait FromValue {
-    fn from_value(&Value) -> &Self;
-}

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -958,7 +958,7 @@ extractValue d t = parens $
         "|" <> vALUE_VAR <> ": Value| {"                                                              $$
         "match" <+> vALUE_VAR <+> "{"                                                                 $$
         "    Value::" <> mkValConstructorName' d t' <> "(x) => {" <+> boxDeref d t' "x" <+> "},"      $$
-        "    _ => panic!(\"unexpected constructor\")"                                                 $$
+        "    _ => unreachable!()"                                                                     $$
         "}}"
     where t' = typeNormalize d t
 
@@ -1047,7 +1047,7 @@ compileKey d rel@Relation{..} KeyExpr{..} = do
         "    Value::" <> mkValConstructorName' d relType <> "(__" <> pp keyVar <> ") => {"            $$
         "       let" <+> pp keyVar <+> "= &*__" <> pp keyVar <> ";"                                   $$
         "       " <> val <> "},"                                                                      $$
-        "    _ => panic!(\"unexpected constructor in key_func\")"                                     $$
+        "    _ => unreachable!()"                                                                     $$
         "})"
 
 {- Generate Rust representation of a ground fact -}
@@ -1299,16 +1299,15 @@ openTuple d var vs = do
     cons <- mkValConstructorName d t
     let pattern = tupleStruct $ map (("ref" <+>) . pp . name) vs
     let vars = tuple $ map (pp . name) vs
-    -- TODO: use unreachable() instead of panic!()
     return $
         "let" <+> vars <+> "= match" <+> var <+> "{"                                                    $$
         "    " <> cons <> parens ("ref" <+> bOX_VAR) <+> "=> {"                                         $$
         "        match" <+> boxDeref d t ("*" <> bOX_VAR) <+> "{"                                       $$
         "            " <> pattern <+> "=>" <+> vars <> ","                                              $$
-        "            _ => panic!(\"Unexpected value {:?} (expected" <+> cons <+> ")\", " <> var <> ")," $$
+        "            _ => unreachable!(),"                                                              $$
         "        }"                                                                                     $$
         "    },"                                                                                        $$
-        "    _ => panic!(\"Unexpected value {:?} (expected" <+> cons <+> ")\", " <> var <> ")"          $$
+        "    _ => unreachable!()"                                                                       $$
         "};"
 
 -- Generate Rust constructor name for a type

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -851,15 +851,6 @@ mkValType d types =
     tuple0 = "Value::" <> mkValConstructorName' d (tTuple []) <> (parens $ box d (tTuple []) "()")
     mkdisplay :: Type -> Doc
     mkdisplay t = "Value::" <> consname t <+> "(v) => write!(f, \"{:?}\", *v)"
-    {-mkfromval t =
-        "impl FromValue for " <> mkType t <> " {"                                                               $$
-        "    fn from_value(v: &Value) -> &Self {"                                                               $$
-        "        match v {"                                                                                     $$
-        "            Value::" <> consname t <> "(x) => &" <> boxDeref d t "*x" <> ","                           $$
-        "            _ => panic!(\"unexpected constructor\")"                                                   $$
-        "        }"                                                                                             $$
-        "    }"                                                                                                 $$
-        "}"-}
 
 -- Iterate through all rules in the program; precompute the set of arrangements for each
 -- relation.  This is done as a separate compiler pass to maximize arrangement sharing

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -35,7 +35,7 @@ module Language.DifferentialDatalog.Type(
     exprNodeType,
     relKeyType,
     typ', typ'',
-    isBool, isBit, isInt, isString, isStruct, isTuple,
+    isBool, isBit, isInt, isString, isStruct, isTuple, isGroup,
     checkTypesMatch,
     typesMatch,
     typeNormalize,
@@ -50,7 +50,6 @@ module Language.DifferentialDatalog.Type(
     funcGroupArgTypes,
     sET_TYPES,
     gROUP_TYPE,
-    isGroup,
     rEF_TYPE,
     checkIterable,
     typeIterType

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -5,7 +5,12 @@ typedef Aggregate1 = Aggregate1{x: string, cnt: bit<64>}
 typedef Aggregate2 = Aggregate2{x: string, set: std.Set<string>}
 typedef Aggregate3 = Aggregate3{x: string, vec: std.Vec<string>}
 typedef Aggregate4 = Aggregate4{x: string, map: std.Map<string,string>}
+typedef AggregateByX = AggregateByX{x: string, cnt: bit<64>}
+typedef AggregateCnt = AggregateCnt{cnt: bit<64>}
+typedef AggregateCnt2 = AggregateCnt2{cnt: bit<64>}
+typedef AggregateCnt3 = AggregateCnt3{cnt: bit<64>}
 typedef AggregateMe1 = AggregateMe1{x: string, y: string}
+typedef AggregateMe3 = AggregateMe3{x: string, y: string, z: string}
 typedef AggregateMeInts = AggregateMeInts{x: string, y: bit<32>}
 typedef Alloc = Alloc{id: bigint, allocated: std.Map<string,bit<32>>, toallocate: std.Vec<string>, min_val: bit<32>, max_val: bit<32>}
 typedef Allocated = Allocated{name: string, xs: std.Set<bit<32>>}
@@ -471,7 +476,12 @@ output relation Aggregate1 [Aggregate1]
 output relation Aggregate2 [Aggregate2]
 output relation Aggregate3 [Aggregate3]
 output relation Aggregate4 [Aggregate4]
+output relation AggregateByX [AggregateByX]
+output relation AggregateCnt [AggregateCnt]
+output relation AggregateCnt2 [AggregateCnt2]
+output relation AggregateCnt3 [AggregateCnt3]
 input relation AggregateMe1 [AggregateMe1]
+input relation AggregateMe3 [AggregateMe3]
 input relation AggregateMeInts [AggregateMeInts]
 input relation Alloc [Alloc]
 relation Allocated [Allocated]
@@ -665,11 +675,15 @@ Strings(.s="line1\nline2").
 Rel3(.x=x, .y=y, .z=z) :- Rel1(.x=x, .y=y), Rel2(.x=x, .z=z).
 Rel4(.x=x, .y=y, .b=b) :- Rel1(.x=x, .y=y), Rel2(.x=x, .z=Option1{.f1=_, .f2=IP4{.ip4=_}, .f3=(b, "buzz")}).
 Aggregate1(.x=x, .cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((x), std.group_count(y)).
+AggregateCnt(.cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((), std.group_count(())).
+AggregateCnt2(.cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((), std.group_sum((64'd1: bit<64>))).
+AggregateCnt3(.cnt=cnt) :- AggregateMe1(.x=x, .y=y), (y != "1"), var cnt = Aggregate((), std.group_sum((64'd1: bit<64>))).
 Aggregate2(.x=x, .set=set) :- AggregateMe1(.x=x, .y=y), var set = Aggregate((x), std.group2set(y)).
 Aggregate3(.x=x, .vec=vec) :- AggregateMe1(.x=x, .y=y), var vec = Aggregate((x), std.group2vec(y)).
 Aggregate4(.x=x, .map=map) :- AggregateMe1(.x=x, .y=y), var map = Aggregate((x), std.group2map((x, y))).
 Disaggregate(.x=x, .y=y) :- AggregateMe1(.x=x, .y=y), var set = Aggregate((x), std.group2set(y)), var y = FlatMap(set).
 Sum(.x=x, .sum=sum) :- AggregateMeInts(.x=x, .y=y), var sum = Aggregate((x), std.group_sum(y)).
+AggregateByX(.x=x, .cnt=cnt) :- AggregateMe3(.x=x, .y=y, .z=z), AggregateMe1(.x=x, .y=y), var cnt = Aggregate((x), std.group_count(())).
 WithKeyDbg(.key=k, .val=v) :- WithKey(.key=k, .val=v).
 Innocent(.name=name) :- Suspect(.name=name), not Gangster(.nickname=_, .name=name).
 ValidDestination(.addr=addr) :- Address(.addr=addr), IPAddr{.b3=var b3, .b2=var b2, .b1=_, .b0=_} = addr, not Blacklist(.addr=IPAddr{.b3=b3, .b2=b2, .b1=_, .b0=_}).

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -58,10 +58,26 @@ insert AggregateMe1("b", "1"),
 insert AggregateMe1("b", "2"),
 insert AggregateMe1("b", "3");
 
+insert AggregateMe3("a", "1", "z"),
+insert AggregateMe3("a", "2", "z"),
+insert AggregateMe3("a", "3", "z"),
+insert AggregateMe3("b", "1", "z"),
+insert AggregateMe3("b", "2", "z"),
+insert AggregateMe3("b", "3", "z");
+
 commit;
 
 echo Aggregate1;
 dump Aggregate1;
+
+echo AggregateCnt;
+dump AggregateCnt;
+
+echo AggregateCnt2;
+dump AggregateCnt2;
+
+echo AggregateCnt3;
+dump AggregateCnt3;
 
 echo Aggregate2;
 dump Aggregate2;
@@ -71,6 +87,9 @@ dump Aggregate3;
 
 echo Aggregate4;
 dump Aggregate4;
+
+echo AggregateByX;
+dump AggregateByX;
 
 echo Disaggregate;
 dump Disaggregate;

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -616,12 +616,20 @@ input relation AggregateMe1(x: string, y: string)
 output relation Aggregate1(x: string, cnt: bit<64>)
 Aggregate1(x, cnt) :- AggregateMe1(x,y), var cnt = Aggregate((x), group_count(y)).
 
+output relation AggregateCnt(cnt: bit<64>)
+AggregateCnt(cnt) :- AggregateMe1(x,y), var cnt = Aggregate((), group_count(())).
+
+output relation AggregateCnt2(cnt: bit<64>)
+AggregateCnt2(cnt) :- AggregateMe1(x,y), var cnt = Aggregate((), group_sum(1: bit<64>)).
+
+output relation AggregateCnt3(cnt: bit<64>)
+AggregateCnt3(cnt) :- AggregateMe1(x,y), y != "1", var cnt = Aggregate((), group_sum(1: bit<64>)).
+
 output relation Aggregate2(x: string, set: Set<string>)
 Aggregate2(x, set) :- AggregateMe1(x,y), var set = Aggregate((x), group2set(y)).
 
 output relation Aggregate3(x: string, vec: Vec<string>)
 Aggregate3(x, vec) :- AggregateMe1(x,y), var vec = Aggregate((x), group2vec(y)).
-
 
 output relation Aggregate4(x: string, map: Map<string,string>)
 Aggregate4(x, map) :- AggregateMe1(x,y), var map = Aggregate((x), group2map((x,y))).
@@ -629,11 +637,17 @@ Aggregate4(x, map) :- AggregateMe1(x,y), var map = Aggregate((x), group2map((x,y
 output relation Disaggregate(x: string, y: string)
 Disaggregate(x,y) :- AggregateMe1(x,y), var set = Aggregate((x), group2set(y)), var y = FlatMap(set).
 
-
 input relation AggregateMeInts(x: string, y: bit<32>)
 
 output relation Sum(x: string, sum: bit<32>)
 Sum(x, sum) :- AggregateMeInts(x, y), var sum = Aggregate((x), group_sum(y)).
+
+input relation AggregateMe3(x: string, y: string, z: string)
+
+output relation AggregateByX(x: string, cnt: bit<64>)
+
+AggregateByX(x, cnt) :- AggregateMe3(x,y,z), AggregateMe1(x,y),
+                        var cnt = Aggregate((x), group_count(())).
 
 /* Primary key */
 input relation WithKey(key: bit<128>, val: string)

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -152,6 +152,12 @@ Rel3{0,IP4{100},Option1{0,IP4{300},(true, "foo")}}
 Aggregate1
 Aggregate1{"a",3}
 Aggregate1{"b",3}
+AggregateCnt
+AggregateCnt{6}
+AggregateCnt2
+AggregateCnt2{6}
+AggregateCnt3
+AggregateCnt3{4}
 Aggregate2
 Aggregate2{"a",std_Set { x: {"1", "2", "3"} }}
 Aggregate2{"b",std_Set { x: {"1", "2", "3"} }}
@@ -161,6 +167,9 @@ Aggregate3{"b",std_Vec { x: ["1", "2", "3"] }}
 Aggregate4
 Aggregate4{"a",std_Map { x: {"a": "3"} }}
 Aggregate4{"b",std_Map { x: {"b": "3"} }}
+AggregateByX
+AggregateByX{"a",3}
+AggregateByX{"b",3}
 Disaggregate
 Disaggregate{"a","1"}
 Disaggregate{"a","2"}


### PR DESCRIPTION
We used to treat groups as sets, e.g., given relation with records

```
|x|y|z|
|-----|
|1|1|1|
|1|2|1|
|1|3|1|
|-----|
```

the following rule fragment

```
R(x,y,z), var a = Aggregate((x), group_count(z))
```

will return the number of all distinct values of `z` for each `x`:

```
|z|a|
|---|
|1|1|
|---|
```

This is counterintuitive and is different from how other Datalog engines
work.  The new semantics treats each group as a multiset and will
produce

```
|z|a|
|---|
|1|3|
|---|
```

in the above example.

Implementation details
----------------------

The multiset semantics is maintained by keeping a tuple of all live
variables in each element in the group and applying a projection
function to it to obtain the argument to the aggregation function.

The good: this design avoids having to apply `distinct` before aggregation and,
furthemore enables arrangement reuse for aggregations (which was not
possible before)

The bad: currently, the projection function always returns an owned value, not
a reference, introducing an extra copy, which can be expensive for large
values.