### PR TITLE
Additional fix for single-quote escaping

### DIFF
--- a/lib/intern.rs
+++ b/lib/intern.rs
@@ -8,6 +8,7 @@ use std::collections;
 use std::sync;
 use serde;
 use differential_datalog::record::Record;
+use differential_datalog::record;
 
 type Symbol = u32;
 
@@ -70,14 +71,14 @@ pub fn intern_istring_ord(s: &intern_IString) -> u32 {
 
 impl fmt::Display for intern_IString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&intern_istring_str(self), f)
+        record::format_ddlog_str(&intern_istring_str(self), f)
     }
 }
 
 
 impl fmt::Debug for intern_IString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&intern_istring_str(self), f)
+        record::format_ddlog_str(&intern_istring_str(self), f)
     }
 }
 

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -23,17 +23,13 @@ pub fn format_ddlog_str(s: &str, f: &mut fmt::Formatter) -> fmt::Result {
     f.write_char('"')?;
     let mut from = 0;
     for (i, c) in s.char_indices() {
-        if c == '\'' {
-            f.write_char('\'')?;
-        } else {
-            let esc = c.escape_debug();
-            if esc.len() != 1 {
-                f.write_str(&s[from..i])?;
-                for c in esc {
-                    f.write_char(c)?;
-                }
-                from = i + c.len_utf8();
+        let esc = c.escape_debug();
+        if esc.len() != 1 && c != '\'' {
+            f.write_str(&s[from..i])?;
+            for c in esc {
+                f.write_char(c)?;
             }
+            from = i + c.len_utf8();
         }
     }
     f.write_str(&s[from..])?;


### PR DESCRIPTION
- Single quoutes were still incorrectly escaped in interned strings
- My custom string formatting function had a bug