### PR TITLE
Update handler framework

### DIFF
--- a/doc/testing/testing.md
+++ b/doc/testing/testing.md
@@ -67,6 +67,7 @@ outputs.
 | ------------------------------ |--------------------------------------------------| -----------------------------------------------------------------------|
 | `start;`                       |                                                  | start a transaction                                                    |
 | `commit;`                      |                                                  | commit current transaction                                             |
+| `commit dump_changes;`         |                                                  | commit current transaction and dump all changes to output relations    |
 | `rollback;`                    |                                                  | rollback current transaction; reverting all changes                    |
 | `timestamp;`                   |                                                  | print current time in ns since some unspecified epoch                  |
 | `dump;`                        |                                                  | dump the content of all relations                                      |

--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -233,6 +233,11 @@ JNIEXPORT jstring JNICALL Java_ddlogapi_DDlogAPI_ddlog_1profile(
     return result;
 }
 
+JNIEXPORT jint JNICALL Java_ddlogapi_DDlogAPI_ddlog_1enable_1cpu_1profiling(
+    JNIEnv *env, jobject obj, jlong progHandle, jboolean enable) {
+    return ddlog_enable_cpu_profiling((ddlog_prog)progHandle, enable);
+}
+
 JNIEXPORT jlong JNICALL Java_ddlogapi_DDlogAPI_ddlog_1bool(
     JNIEnv *env, jclass obj, jboolean b) {
     return (jlong)ddlog_bool(b);

--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -113,8 +113,7 @@ JNIEXPORT jlong JNICALL Java_ddlogapi_DDlogAPI_ddlog_1run(
 }
 
 JNIEXPORT jint JNICALL Java_ddlogapi_DDlogAPI_ddlog_1record_1commands(
-    JNIEnv *env, jobject obj, jlong handle, jstring filename)
-{
+    JNIEnv *env, jobject obj, jlong handle, jstring filename) {
     int ret;
     int fd;
 

--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -26,6 +26,7 @@ public class DDlogAPI {
     static native int ddlog_transaction_rollback(long hprog);
     static native int ddlog_apply_updates(long hprog, long[] upds);
     static native String ddlog_profile(long hprog);
+    static native int ddlog_enable_cpu_profiling(long hprog, boolean enable);
 
     // All the following methods return in fact handles
     static public native void ddlog_free(long handle);
@@ -225,5 +226,9 @@ public class DDlogAPI {
 
     public String profile() {
         return DDlogAPI.ddlog_profile(this.hprog);
+    }
+
+    public int enable_cpu_profiling(boolean enable) {
+        return DDlogAPI.ddlog_enable_cpu_profiling(this.hprog, enable);
     }
 }

--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -88,8 +88,6 @@ public class DDlogAPI {
 
     // Callback to invoke for each modified record on commit_dump_changes.
     // The command supplied to a callback can only have an Insert or DeleteValue 'kind'.
-    // In the current implementation this callback is invoked sequentially
-    // by the same DDlog worker thread.
     private Consumer<DDlogCommand> deltaCallback;
 
     // Callback to invoke for each record on `DDlogAPI.dump()`.

--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -114,10 +114,6 @@ public class DDlogAPI {
         this.hprog = this.ddlog_run(storeData, workers, onCommit);
     }
 
-    public DDlogAPI(int workers, Consumer<DDlogCommand> callback) {
-        this(workers, callback, callback == null);
-    }
-
     /// Callback invoked from commit.
     void onCommit(int tableid, long handle, boolean polarity) {
         if (this.commitCallback != null) {

--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -221,10 +221,7 @@ public class DDlogAPI {
         return this.dump_table(this.hprog, id, "dumpCallback");
     }
 
-    public int profile() {
-        String s = DDlogAPI.ddlog_profile(this.hprog);
-        System.out.println("Profile:");
-        System.out.println(s);
-        return 0;
+    public String profile() {
+        return DDlogAPI.ddlog_profile(this.hprog);
     }
 }

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -283,6 +283,7 @@ public class SpanTest {
                     this.checkSemicolon();
                     break;
                 case "commit":
+                    //this.exitCode = this.api.commit_dump_changes(r -> System.err.println(r.toString()));
                     this.exitCode = this.api.commit();
                     this.checkExitCode();
                     this.checkSemicolon();

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -312,11 +312,20 @@ public class SpanTest {
                     }
                     break;
                 case "profile":
-                    String profile = this.api.profile();
-                    System.out.println("Profile:");
-                    System.out.println(profile);
-                    this.checkExitCode();
-                    this.checkSemicolon();
+                    if (rest.equals(" cpu on")) {
+                        this.exitCode = this.api.enable_cpu_profiling(true);
+                        this.checkExitCode();
+                    } else if (rest.equals(" cpu off")) {
+                        this.exitCode = this.api.enable_cpu_profiling(false);
+                        this.checkExitCode();
+                    } else if (rest.equals("")) {
+                        String profile = this.api.profile();
+                        System.out.println("Profile:");
+                        System.out.println(profile);
+                        this.checkSemicolon();
+                    } else {
+                        throw new RuntimeException("Unexpected command " + line);
+                    }
                     break;
                 case "dump":
                     // Hardwired output relation name

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -106,6 +106,7 @@ public class SpanTest {
             if (localTables) {
                 //this.api = new DDlogAPI(1, r -> this.onCommit(r));
                 this.api = new DDlogAPI(1, r -> this.onCommitDirect(r));
+                this.api.record_commands("replay.dat");
                 this.ruleSpanTableId = this.api.getTableId("RuleSpan");
                 this.containerSpanTableId = this.api.getTableId("ContainerSpan");
                 this.ruleSpan = new TreeSet<RuleSpan>(new SpanComparator());

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -43,6 +43,13 @@ public class SpanTest {
             this.tn = tn;
         }
 
+        protected SpanBase(DDlogRecord r) {
+            DDlogRecord entity = r.getStructField(0);
+            DDlogRecord tn = r.getStructField(1);
+            this.entity = entity.getU128();
+            this.tn = tn.getU128();
+        }
+
         @Override
         public String toString() {
             return this.getClass().getSimpleName() + "{" +
@@ -62,10 +69,12 @@ public class SpanTest {
         // We need an empty constructor for reflection to work.
         public RuleSpan() {}
         public RuleSpan(final BigInteger entity, final BigInteger tn) { super(entity, tn); }
+        public RuleSpan(DDlogRecord r) { super(r); }
     }
     public static final class ContainerSpan extends SpanBase {
         public ContainerSpan() {}
         public ContainerSpan(final BigInteger entity, final BigInteger tn) { super(entity, tn); }
+        public ContainerSpan(DDlogRecord r) { super(r); }
     }
     public static final class Binding extends SpanBase {
         public Binding(final BigInteger entity, final BigInteger tn) { super(entity, tn); }
@@ -100,7 +109,7 @@ public class SpanTest {
         private static Set<ContainerSpan> containerSpan;
         private int ruleSpanTableId;
         private int containerSpanTableId;
-        private boolean localTables = true;
+        private boolean localTables = false;
 
         SpanParser() {
             if (localTables) {
@@ -321,8 +330,14 @@ public class SpanTest {
                             System.out.println(s);
                         System.out.println();
                     } else {
-                        this.exitCode = this.api.dump("ContainerSpan");
-                        this.exitCode = this.api.dump("RuleSpan");
+                        System.out.println("ContainerSpan:");
+                        this.exitCode = this.api.dump("ContainerSpan",
+                                r -> System.out.println(new ContainerSpan(r)));
+                        System.out.println();
+                        System.out.println("RuleSpan:");
+                        this.exitCode = this.api.dump("RuleSpan",
+                                r -> System.out.println(new RuleSpan(r)));
+                        System.out.println();
                         this.checkExitCode();
                         this.checkSemicolon();
                     }
@@ -345,8 +360,10 @@ public class SpanTest {
                     }
                 });
             this.api.stop();
-            this.ruleSpan.clear();
-            this.containerSpan.clear();
+            if (localTables) {
+                this.ruleSpan.clear();
+                this.containerSpan.clear();
+            }
         }
     }
 

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -114,14 +114,14 @@ public class SpanTest {
         SpanParser() {
             if (localTables) {
                 //this.api = new DDlogAPI(1, r -> this.onCommit(r));
-                this.api = new DDlogAPI(1, r -> this.onCommitDirect(r));
+                this.api = new DDlogAPI(1, r -> this.onCommitDirect(r), false);
                 this.api.record_commands("replay.dat");
                 this.ruleSpanTableId = this.api.getTableId("RuleSpan");
                 this.containerSpanTableId = this.api.getTableId("ContainerSpan");
                 this.ruleSpan = new TreeSet<RuleSpan>(new SpanComparator());
                 this.containerSpan = new TreeSet<ContainerSpan>(new SpanComparator());
             } else {
-                this.api = new DDlogAPI(1, null);
+                this.api = new DDlogAPI(1, null, true);
             }
             this.command = null;
             this.exitCode = -1;

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -303,7 +303,9 @@ public class SpanTest {
                     }
                     break;
                 case "profile":
-                    this.exitCode = this.api.profile();
+                    String profile = this.api.profile();
+                    System.out.println("Profile:");
+                    System.out.println(profile);
                     this.checkExitCode();
                     this.checkSemicolon();
                     break;

--- a/java/test1/RedistTest.java
+++ b/java/test1/RedistTest.java
@@ -386,11 +386,20 @@ public class RedistTest {
                         this.runCommands();
                     break;
                 case "profile":
-                    String profile = this.api.profile();
-                    System.out.println("Profile:");
-                    System.out.println(profile);
-                    this.checkExitCode();
-                    this.checkSemicolon();
+                    if (rest.equals(" cpu on")) {
+                        this.exitCode = this.api.enable_cpu_profiling(true);
+                        this.checkExitCode();
+                    } else if (rest.equals(" cpu off")) {
+                        this.exitCode = this.api.enable_cpu_profiling(false);
+                        this.checkExitCode();
+                    } else if (rest.equals("")) {
+                        String profile = this.api.profile();
+                        System.out.println("Profile:");
+                        System.out.println(profile);
+                        this.checkSemicolon();
+                    } else {
+                        throw new RuntimeException("Unexpected command " + line);
+                    }
                     break;
                 case "dump":
                     // Hardwired output relation name

--- a/rust/template/api.rs
+++ b/rust/template/api.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, unused_parens, non_shorthand_field_patterns, dead_code, overflowing_literals)]
-
 use differential_datalog::program::*;
 use differential_datalog::record;
 use differential_datalog::record::IntoRecord;

--- a/rust/template/api.rs
+++ b/rust/template/api.rs
@@ -344,9 +344,9 @@ pub unsafe extern "C" fn ddlog_transaction_commit(prog: *const HDDlog) -> raw::c
 unsafe fn record_transaction_commit(prog: &Arc<HDDlog>, record_changes: bool) {
     if let Some(ref f) = prog.replay_file {
         let res = if record_changes {
-            write!(f.lock().unwrap(), "commit;\n")
-        } else {
             write!(f.lock().unwrap(), "commit dump_changes;\n")
+        } else {
+            write!(f.lock().unwrap(), "commit;\n")
         };
         if res.is_err() {
             prog.eprintln("ddlog_transaction_commit(): failed to record invocation in replay file");

--- a/rust/template/api.rs
+++ b/rust/template/api.rs
@@ -1,0 +1,492 @@
+#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, unused_parens, non_shorthand_field_patterns, dead_code, overflowing_literals)]
+
+use differential_datalog::program::*;
+use differential_datalog::record;
+use differential_datalog::record::IntoRecord;
+
+use std::os::raw;
+use std::ptr;
+use std::ffi;
+use std::fs;
+use std::io::Write;
+use std::os::unix;
+use std::os::unix::io::{IntoRawFd, FromRawFd};
+use std::mem;
+use libc::size_t;
+
+use super::valmap;
+use super::update_handler::*;
+use super::*;
+
+pub struct HDDlog {
+    pub prog: sync::Mutex<RunningProgram<Value>>,
+    pub update_handler: Box<dyn IMTUpdateHandler<Value>>,
+    pub db: Option<sync::Arc<sync::Mutex<valmap::ValMap>>>,
+    pub print_err: Option<extern "C" fn(msg: *const raw::c_char)>,
+    /* When set, all commands sent to the program are recorded in
+     * the specified `.dat` file so that they can be replayed later. */
+    pub replay_file: Option<sync::Mutex<fs::File>>
+}
+
+impl HDDlog {
+    pub fn print_err(f: Option<extern "C" fn(msg: *const raw::c_char)>, msg: &str) {
+        match f {
+            None    => eprintln!("{}", msg),
+            Some(f) => f(ffi::CString::new(msg).unwrap().into_raw())
+        }
+    }
+
+    pub fn eprintln(&self, msg: &str)
+    {
+        Self::print_err(self.print_err, msg)
+    }
+}
+
+pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String>
+{
+    match c {
+        record::UpdCmd::Insert(rident, rec) => {
+            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
+            let val = relval_from_record(relid, rec)?;
+            Ok(Update::Insert{relid: relid as RelId, v: val})
+        },
+        record::UpdCmd::Delete(rident, rec) => {
+            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
+            let val = relval_from_record(relid, rec)?;
+            Ok(Update::DeleteValue{relid: relid as RelId, v: val})
+        },
+        record::UpdCmd::DeleteKey(rident, rec) => {
+            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
+            let key = relkey_from_record(relid, rec)?;
+            Ok(Update::DeleteKey{relid: relid as RelId, k: key})
+        },
+        record::UpdCmd::Modify(rident, key, rec) => {
+            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
+            let key = relkey_from_record(relid, key)?;
+            Ok(Update::Modify{relid: relid as RelId, k: key, m: Box::new(rec.clone())})
+        }
+    }
+}
+
+fn relident2id(r: &record::RelIdentifier) -> Option<Relations> {
+    match r {
+        record::RelIdentifier::RelName(rname) => relname2id(rname),
+        record::RelIdentifier::RelId(id)      => relid2rel(*id)
+    }
+}
+
+fn relident2name(r: &record::RelIdentifier) -> Option<&str> {
+    match r {
+        record::RelIdentifier::RelName(rname) => Some(rname.as_ref()),
+        record::RelIdentifier::RelId(id)      => relid2name(*id)
+    }
+}
+
+fn __null_cb(_relid: RelId, _v: &Value, _w: isize) {}
+
+#[no_mangle]
+pub extern "C" fn ddlog_get_table_id(tname: *const raw::c_char) -> libc::size_t
+{
+    if tname.is_null() {
+        return libc::size_t::max_value();
+    };
+    match get_table_id(tname) {
+        Ok(relid) => relid as libc::size_t,
+        Err(_) => {
+            libc::size_t::max_value()
+        }
+    }
+}
+
+fn get_table_id(tname: *const raw::c_char) -> Result<Relations, String>
+{
+    let table_str = unsafe{ ffi::CStr::from_ptr(tname) }.to_str().map_err(|e| format!("{}", e))?;
+    relname2id(table_str).ok_or_else(||format!("unknown relation {}", table_str))
+}
+
+#[no_mangle]
+pub extern "C" fn ddlog_run(
+    workers: raw::c_uint,
+    do_store: bool,
+    cb: Option<extern "C" fn(arg: libc::uintptr_t,
+                             table: libc::size_t,
+                             rec: *const record::Record,
+                             polarity: bool)>,
+    cb_arg:  libc::uintptr_t,
+    print_err: Option<extern "C" fn(msg: *const raw::c_char)>) -> *const HDDlog
+{
+    let workers = if workers == 0 { 1 } else { workers };
+
+    let db: sync::Arc<sync::Mutex<valmap::ValMap>> = sync::Arc::new(sync::Mutex::new(valmap::ValMap::new()));
+    let mut handlers: Vec<Box<dyn IMTUpdateHandler<Value>>> = Vec::new();
+    if do_store {
+        handlers.push(Box::new(MTValMapUpdateHandler::new(db.clone())));
+    };
+    match cb {
+        None => {},
+        Some(cb) => handlers.push(Box::new(ExternCUpdateHandler::new(cb, cb_arg)))
+    };
+
+    let handler: Box<dyn IMTUpdateHandler<Value>> = if handlers.len() == 0 {
+        Box::new(NullUpdateHandler::new())
+    } else if handlers.len() == 1 {
+        handlers[0].clone()
+    } else {
+        Box::new(MTChainedUpdateHandler::new(handlers))
+    };
+
+    let program = prog(handler.mt_update_cb());
+
+    /* Notify handler about initial transaction */
+    handler.before_commit();
+    let prog = program.run(workers as usize);
+    handler.after_commit(true);
+
+    sync::Arc::into_raw(sync::Arc::new(HDDlog{
+        prog:           sync::Mutex::new(prog),
+        update_handler: handler,
+        db:             Some(db),
+        print_err:      print_err,
+        replay_file:    None}))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_record_commands(prog: *const HDDlog, fd: unix::io::RawFd) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    let mut prog = sync::Arc::from_raw(prog);
+    let res = match sync::Arc::get_mut(&mut prog) {
+        Some(prog) => {
+            /* Swap out the old file and convert it into FD to prevent
+             * the file from closing on destruction (it is the caller's
+             * responsibility to close the file when they're done with it). */
+            let mut old_file = if fd == -1 {
+                None
+            } else {
+                Some(sync::Mutex::new(fs::File::from_raw_fd(fd)))
+            };
+            mem::swap(&mut prog.replay_file, &mut old_file);
+            match old_file {
+                None => (),
+                Some(m) => {
+                    m.into_inner().unwrap().into_raw_fd();
+                }
+            };
+            0
+        },
+        None => -1
+    };
+    sync::Arc::into_raw(prog);
+    res
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_stop(prog: *const HDDlog) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    /* Prevents closing of the old descriptor. */
+    ddlog_record_commands(prog, -1);
+
+    let prog = sync::Arc::from_raw(prog);
+    match sync::Arc::try_unwrap(prog) {
+        Ok(HDDlog{prog, print_err, ..}) => prog.into_inner().map(|p|{p.stop(); 0}).unwrap_or_else(|e|{
+            HDDlog::print_err(print_err, &format!("ddlog_stop(): error acquiring lock: {}", e));
+            -1
+        }),
+        Err(pref) => {
+            pref.eprintln("ddlog_stop(): cannot extract value from Arc");
+            -1
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_transaction_start(prog: *const HDDlog) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_transaction_start(&prog);
+
+    let res = prog.prog.lock().unwrap().transaction_start().map(|_|0).unwrap_or_else(|e|{
+        prog.eprintln(&format!("ddlog_transaction_start(): error: {}", e));
+        -1
+    });
+    sync::Arc::into_raw(prog);
+    res
+}
+
+unsafe fn record_transaction_start(prog: &sync::Arc<HDDlog>) {
+    if let Some(ref f) = prog.replay_file {
+        if write!(f.lock().unwrap(), "start;\n").is_err() {
+            prog.eprintln("ddlog_transaction_start(): failed to record invocation in replay file");
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_transaction_commit(prog: *const HDDlog) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_transaction_commit(&prog);
+    prog.update_handler.before_commit();
+
+    let res = prog.prog.lock().unwrap().transaction_commit().map(|_|0).unwrap_or_else(|e|{
+        prog.update_handler.after_commit(false);
+        prog.eprintln(&format!("ddlog_transaction_commit(): error: {}", e));
+        -1
+    });
+    prog.update_handler.after_commit(true);
+    sync::Arc::into_raw(prog);
+    res
+}
+
+unsafe fn record_transaction_commit(prog: &sync::Arc<HDDlog>) {
+    if let Some(ref f) = prog.replay_file {
+        if write!(f.lock().unwrap(), "commit;\n").is_err() {
+            prog.eprintln("ddlog_transaction_commit(): failed to record invocation in replay file");
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_transaction_rollback(prog: *const HDDlog) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_transaction_rollback(&prog);
+
+    let res = prog.prog.lock().unwrap().transaction_rollback().map(|_|0).unwrap_or_else(|e|{
+        prog.eprintln(&format!("ddlog_transaction_rollback(): error: {}", e));
+        -1
+    });
+    sync::Arc::into_raw(prog);
+    res
+}
+
+unsafe fn record_transaction_rollback(prog: &sync::Arc<HDDlog>) {
+    if let Some(ref f) = prog.replay_file {
+        if write!(f.lock().unwrap(), "rollback;\n").is_err() {
+            prog.eprintln("ddlog_transaction_rollback(): failed to record invocation in replay file");
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_apply_updates(prog: *const HDDlog, upds: *const *mut record::UpdCmd, n: size_t) -> raw::c_int
+{
+    if prog.is_null() || upds.is_null() {
+        return -1;
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_updates(&prog, upds, n);
+
+    let mut upds_vec = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        let upd = match updcmd2upd(Box::from_raw(*upds.offset(i as isize)).as_ref()) {
+            Ok(upd) => upd,
+            Err(e) => {
+                prog.eprintln(&format!("ddlog_apply_updates(): invalid argument: {}", e));
+                return -1;
+            }
+        };
+        upds_vec.push(upd);
+    };
+    let res = prog.prog.lock().unwrap().apply_updates(upds_vec).map(|_|0).unwrap_or_else(|e|{
+        prog.eprintln(&format!("ddlog_apply_updates(): error: {}", e));
+        return -1;
+    });
+    sync::Arc::into_raw(prog);
+    res
+}
+
+unsafe fn record_updates(prog: &sync::Arc<HDDlog>, upds: *const *mut record::UpdCmd, n: size_t)
+{
+    if let Some(ref f) = prog.replay_file {
+        let mut file = f.lock().unwrap();
+        for i in 0..n {
+            let sep = if i == n - 1 { ";" } else { "," };
+            record_update(&mut *file, &(**upds.offset(i as isize)));
+            let _ = write!(file, "{}\n", sep);
+        }
+    }
+}
+
+pub fn record_update(file: &mut fs::File, upd: &record::UpdCmd)
+{
+    match upd {
+        record::UpdCmd::Insert(rel, record) => {
+            let _ = write!(file, "insert {}[{}]", relident2name(rel).unwrap_or(&"???"), record);
+        },
+        record::UpdCmd::Delete(rel, record) => {
+            let _ = write!(file, "delete {}[{}]", relident2name(rel).unwrap_or(&"???"), record);
+        },
+        record::UpdCmd::DeleteKey(rel, record) => {
+            let _ = write!(file, "delete_key {} {}", relident2name(rel).unwrap_or(&"???"), record);
+        },
+        record::UpdCmd::Modify(rel, key, mutator) => {
+            let _ = write!(file, "modify {} {} <- {}", relident2name(rel).unwrap_or(&"???"), key, mutator);
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_clear_relation(
+    prog: *const HDDlog,
+    table: libc::size_t) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_clear_relation(&prog, table);
+
+    let res = match clear_relation(&prog, table) {
+        Ok(()) => { 0 },
+        Err(e) => {
+            prog.eprintln(&format!("ddlog_clear_relation(): error: {}", e));
+            -1
+        }
+    };
+    sync::Arc::into_raw(prog);
+    res
+}
+
+unsafe fn record_clear_relation(prog: &sync::Arc<HDDlog>, table: libc::size_t) {
+    if let Some(ref f) = prog.replay_file {
+        if write!(f.lock().unwrap(), "clear {};\n", relid2name(table).unwrap_or(&"???")).is_err() {
+            prog.eprintln("ddlog_clear_relation(): failed to record invocation in replay file");
+        }
+    }
+}
+
+unsafe fn clear_relation(prog: &HDDlog, table: libc::size_t) -> Result<(), String> {
+    prog.prog.lock().unwrap().clear_relation(table)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_dump_table(
+    prog:    *const HDDlog,
+    table:   libc::size_t,
+    cb:      extern "C" fn(arg: *mut raw::c_void, rec: *const record::Record) -> bool,
+    cb_arg:  *mut raw::c_void) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_dump_table(&prog, table);
+
+    let res = if let Some(ref db) = prog.db {
+        match dump_table(&mut db.lock().unwrap(), table, cb, cb_arg) {
+            Ok(_) => {
+                0
+            },
+            Err(e) => {
+                prog.eprintln(&format!("ddlog_dump_table(): error: {}", e));
+                -1
+            }
+        }
+    } else {
+        prog.eprintln("ddlog_dump_table(): cannot dump table: ddlog_run() was invoked with do_store flag set to false");
+        -1
+    };
+    sync::Arc::into_raw(prog);
+    res
+}
+
+unsafe fn record_dump_table(prog: &sync::Arc<HDDlog>, table: libc::size_t) {
+    if let Some(ref f) = prog.replay_file {
+        if write!(f.lock().unwrap(), "dump {};\n", relid2name(table).unwrap_or(&"???")).is_err() {
+            prog.eprintln("ddlog_dump_table(): failed to record invocation in replay file");
+        }
+    }
+}
+
+fn dump_table(db: &mut valmap::ValMap,
+              table: libc::size_t,
+              cb: extern "C" fn(arg: *mut raw::c_void, rec: *const record::Record) -> bool,
+              cb_arg: *mut raw::c_void) -> Result<(), String>
+{
+    for val in db.get_rel(table) {
+        if !cb(cb_arg, &val.clone().into_record() as *const record::Record) {
+            break;
+        }
+    };
+    Ok(())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_enable_cpu_profiling(prog: *const HDDlog, enable: bool) -> raw::c_int
+{
+    if prog.is_null() {
+        return -1;
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_enable_cpu_profiling(&prog, enable);
+
+    prog.prog.lock().unwrap().enable_cpu_profiling(enable);
+    sync::Arc::into_raw(prog);
+    0
+}
+
+fn record_enable_cpu_profiling(prog: &sync::Arc<HDDlog>, enable: bool) {
+    if let Some(ref f) = prog.replay_file {
+        if write!(f.lock().unwrap(), "profile cpu {};\n", if enable { "on" } else { "off" }).is_err() {
+            prog.eprintln("ddlog_cpu_profiling_enable(): failed to record invocation in replay file");
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_profile(prog: *const HDDlog) -> *const raw::c_char
+{
+    if prog.is_null() {
+        return ptr::null();
+    };
+    let prog = sync::Arc::from_raw(prog);
+
+    record_profile(&prog);
+
+    let res = {
+        let rprog = prog.prog.lock().unwrap();
+        let profile = format!("{}", rprog.profile.lock().unwrap());
+        ffi::CString::new(profile).expect("Failed to convert profile string to C").into_raw()
+    };
+    sync::Arc::into_raw(prog);
+    res
+}
+
+unsafe fn record_profile(prog: &sync::Arc<HDDlog>) {
+    if let Some(ref f) = prog.replay_file {
+        if write!(f.lock().unwrap(), "profile;\n").is_err() {
+            prog.eprintln("ddlog_profile(): failed to record invocation in replay file");
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ddlog_string_free(s: *mut raw::c_char)
+{
+    if s.is_null() {
+        return;
+    };
+    unsafe { ffi::CString::from_raw(s); }
+}

--- a/rust/template/cmd_parser/parse.rs
+++ b/rust/template/cmd_parser/parse.rs
@@ -15,7 +15,7 @@ pub enum ProfileCmd {
 #[derive(Debug,PartialEq,Eq,Clone)]
 pub enum Command {
     Start,
-    Commit,
+    Commit(bool),
     Comment,
     Rollback,
     Timestamp,
@@ -60,7 +60,10 @@ named!(pub parse_command<&[u8], Command>,
     do_parse!(
         spaces >>
         upd: alt!(do_parse!(apply!(sym,"start")     >> apply!(sym,";") >> (Command::Start))     |
-                  do_parse!(apply!(sym,"commit")    >> apply!(sym,";") >> (Command::Commit))    |
+                  do_parse!(apply!(sym,"commit")    >>
+                            delta: opt!(apply!(sym, "dump_changes"))   >>
+                            apply!(sym,";")         >>
+                            (Command::Commit(delta.is_some())))                                 |
                   do_parse!(apply!(sym,"timestamp") >> apply!(sym,";") >> (Command::Timestamp)) |
                   do_parse!(apply!(sym,"#")         >> take_until!("\n") >> (Command::Comment)) |
                   do_parse!(apply!(sym,"profile")   >>

--- a/rust/template/differential_datalog/int.rs
+++ b/rust/template/differential_datalog/int.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use abomonation::Abomonation;
 use num::bigint::{BigInt};
 #[cfg(test)]

--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -193,23 +193,23 @@ pub enum ProgNode<V: Val> {
 }
 
 pub trait CBFn<V>: Fn(RelId, &V, bool) + Send {
-   fn clone_boxed(&self) -> Box<dyn CBFn<V>>;
+    fn clone_boxed(&self) -> Box<dyn CBFn<V>>;
 }
 
 impl<T, V> CBFn<V> for T
 where
-   V: Val,
-   T: 'static + Send + Clone + Fn(RelId, &V, bool)
+    V: Val,
+    T: 'static + Send + Clone + Fn(RelId, &V, bool)
 {
-   fn clone_boxed(&self) -> Box<dyn CBFn<V>> {
-       Box::new(self.clone())
-   }
+    fn clone_boxed(&self) -> Box<dyn CBFn<V>> {
+        Box::new(self.clone())
+    }
 }
 
 impl <V: Val> Clone for Box<dyn CBFn<V>> {
-   fn clone(&self) -> Self {
-       self.as_ref().clone_boxed()
-   }
+    fn clone(&self) -> Self {
+        self.as_ref().clone_boxed()
+    }
 }
 
 /// Datalog relation.

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -202,11 +202,10 @@ fn arrange_fun1(v: Value) -> Option<(Value, Value)> {
     }
 }*/
 
-fn set_update(_rel: &str, s: &Arc<Mutex<ValSet<Value>>>, x : &Value, w: Weight)
+fn set_update(_rel: &str, s: &Arc<Mutex<ValSet<Value>>>, x : &Value, w: bool)
 {
-    debug_assert!(w == 1 || w == -1);
     //println!("set_update({}) {:?} {}", rel, *x, insert);
-    if w==1 {
+    if w {
         s.lock().unwrap().insert(x.clone());
     } else {
         s.lock().unwrap().remove(x);

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -212,8 +212,6 @@ fn set_update(_rel: &str, s: &Arc<Mutex<ValSet<Value>>>, x : &Value, w: bool)
     }
 }
 
-
-
 /* Test insertion/deletion into a database with a single table and no rules
  */
 fn test_one_relation(nthreads: usize) {

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -229,7 +229,7 @@ fn test_one_relation(nthreads: usize) {
             id:           1,
             rules:        Vec::new(),
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))))
         }
     };
 
@@ -322,7 +322,7 @@ fn test_two_relations(nthreads: usize) {
             id:           1,
             rules:        Vec::new(),
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))))
         }
     };
     let relset2: Arc<Mutex<ValSet<Value>>> = Arc::new(Mutex::new(FnvHashSet::default()));
@@ -336,7 +336,7 @@ fn test_two_relations(nthreads: usize) {
             id:           2,
             rules:        vec![Rule::CollectionRule{description: "T2.R1".to_string(), rel: 1, xform: None}],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))))
         }
     };
 
@@ -417,7 +417,7 @@ fn test_semijoin(nthreads: usize) {
             id:           1,
             rules:        Vec::new(),
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))))
         }
     };
     fn fmfun1(v: Value) -> Option<Value> {
@@ -448,7 +448,7 @@ fn test_semijoin(nthreads: usize) {
                 fmfun: &(fmfun1 as FilterMapFunc<Value>),
                 distinct: false
             }],
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))))
         }
     };
     fn jfun(_key: &Value, v1: &Value, _v2: &()) -> Option<Value> {
@@ -482,7 +482,7 @@ fn test_semijoin(nthreads: usize) {
                         })
                 }],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))))
         }
     };
 
@@ -536,7 +536,7 @@ fn test_join(nthreads: usize) {
             id:           1,
             rules:        Vec::new(),
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))))
         }
     };
     fn afun1(v: Value) -> Option<(Value, Value)> {
@@ -559,7 +559,7 @@ fn test_join(nthreads: usize) {
                 name: "arrange2.0".to_string(),
                 afun: &(afun1 as ArrangeFunc<Value>)
             }],
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))))
         }
     };
     fn jfun(_key: &Value, v1: &Value, v2: &Value) -> Option<Value> {
@@ -593,7 +593,7 @@ fn test_join(nthreads: usize) {
                         })
                 }],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))))
         }
     };
 
@@ -608,7 +608,7 @@ fn test_join(nthreads: usize) {
             id:           4,
             rules:        Vec::new(),
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T4", &relset4, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T4", &relset4, v, pol)))))
         }
     };
 
@@ -680,7 +680,7 @@ fn test_antijoin(nthreads: usize) {
             id:           1,
             rules:        Vec::new(),
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))))
         }
     };
     fn afun1(v: Value) -> Option<(Value, Value)> {
@@ -710,7 +710,7 @@ fn test_antijoin(nthreads: usize) {
             id:           2,
             rules:        Vec::new(),
             arrangements: vec![],
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))))
         }
     };
 
@@ -751,7 +751,7 @@ fn test_antijoin(nthreads: usize) {
                     fmfun: &(fmnull_fun as FilterMapFunc<Value>),
                     distinct: true
                 }],
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T21", &relset21, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T21", &relset21, v, pol)))))
         }
     };
 
@@ -782,7 +782,7 @@ fn test_antijoin(nthreads: usize) {
                         })
                 }],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))))
         }
     };
 
@@ -846,7 +846,7 @@ fn test_map(nthreads: usize) {
             id:           1,
             rules:        Vec::new(),
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T1", &relset1, v, pol)))))
         }
     };
 
@@ -935,7 +935,7 @@ fn test_map(nthreads: usize) {
                     })
             }],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T2", &relset2, v, pol)))))
         }
     };
     let relset3: Arc<Mutex<ValSet<Value>>> = Arc::new(Mutex::new(FnvHashSet::default()));
@@ -963,7 +963,7 @@ fn test_map(nthreads: usize) {
                     })
             }],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T3", &relset3, v, pol)))))
         }
     };
 
@@ -992,7 +992,7 @@ fn test_map(nthreads: usize) {
                     })
             }],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("T4", &relset4, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("T4", &relset4, v, pol)))))
         }
     };
 
@@ -1097,7 +1097,7 @@ fn test_recursion(nthreads: usize) {
                 name: "arrange_by_parent".to_string(),
                 afun: &(arrange_by_fst as ArrangeFunc<Value>)
             }],
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("parent", &parentset, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("parent", &parentset, v, pol)))))
         }
     };
 
@@ -1142,7 +1142,7 @@ fn test_recursion(nthreads: usize) {
                     afun: &(arrange_by_snd as ArrangeFunc<Value>)
                 }
             ],
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("ancestor", &ancestorset, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("ancestor", &ancestorset, v, pol)))))
         }
     };
 
@@ -1197,7 +1197,7 @@ fn test_recursion(nthreads: usize) {
                     }
                 }],
             arrangements: Vec::new(),
-            change_cb:    Some(Arc::new(move |_,v,pol| set_update("common_ancestor", &common_ancestorset, v, pol)))
+            change_cb:    Some(Arc::new(Mutex::new(Box::new(move |_,v,pol| set_update("common_ancestor", &common_ancestorset, v, pol)))))
         }
     };
 

--- a/rust/template/differential_datalog/uint.rs
+++ b/rust/template/differential_datalog/uint.rs
@@ -1,7 +1,7 @@
+#![allow(non_snake_case)]
+
 use abomonation::Abomonation;
 use num::bigint::{BigUint, BigInt};
-#[cfg(test)]
-use num::bigint::{ToBigInt};
 use std::str::FromStr;
 use std::ops::*;
 use serde::ser::*;

--- a/rust/template/lib.rs
+++ b/rust/template/lib.rs
@@ -186,11 +186,7 @@ pub extern "C" fn ddlog_run(
         Box::new(handler::ChainedDynUpdateHandler::new(handlers))
     };
 
-    let handler2 = handler.clone();
-    let program = prog(Box::new(move |relid, v, w| {
-        debug_assert!(w == 1 || w == -1);
-        handler2.update(relid, v, w == 1)
-    }));
+    let program = prog(handler.update());
     let prog = program.run(workers as usize);
     sync::Arc::into_raw(sync::Arc::new(HDDlog{
         prog:           sync::Mutex::new(prog),

--- a/rust/template/lib.rs
+++ b/rust/template/lib.rs
@@ -54,32 +54,7 @@ use libc::size_t;
 pub mod valmap;
 pub mod update_handler;
 pub mod ovsdb;
-
-use self::update_handler as handler;
-
-pub struct HDDlog {
-    prog: sync::Mutex<RunningProgram<Value>>,
-    update_handler: Box<dyn handler::DynUpdateHandler<Value>>,
-    db: Option<sync::Arc<sync::Mutex<valmap::ValMap>>>,
-    print_err: Option<extern "C" fn(msg: *const raw::c_char)>,
-    /* When set, all commands sent to the program are recorded in
-     * the specified `.dat` file so that they can be replayed later. */
-    replay_file: Option<sync::Mutex<fs::File>>
-}
-
-impl HDDlog {
-    pub fn print_err(f: Option<extern "C" fn(msg: *const raw::c_char)>, msg: &str) {
-        match f {
-            None    => eprintln!("{}", msg),
-            Some(f) => f(ffi::CString::new(msg).unwrap().into_raw())
-        }
-    }
-
-    pub fn eprintln(&self, msg: &str)
-    {
-        Self::print_err(self.print_err, msg)
-    }
-}
+pub mod api;
 
 pub fn string_append_str(mut s1: String, s2: &str) -> String
 {
@@ -93,446 +68,75 @@ pub fn string_append(mut s1: String, s2: &String) -> String
     s1
 }
 
-pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String>
-{
-    match c {
-        record::UpdCmd::Insert(rident, rec) => {
-            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
-            let val = relval_from_record(relid, rec)?;
-            Ok(Update::Insert{relid: relid as RelId, v: val})
-        },
-        record::UpdCmd::Delete(rident, rec) => {
-            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
-            let val = relval_from_record(relid, rec)?;
-            Ok(Update::DeleteValue{relid: relid as RelId, v: val})
-        },
-        record::UpdCmd::DeleteKey(rident, rec) => {
-            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
-            let key = relkey_from_record(relid, rec)?;
-            Ok(Update::DeleteKey{relid: relid as RelId, k: key})
-        },
-        record::UpdCmd::Modify(rident, key, rec) => {
-            let relid: Relations = relident2id(rident).ok_or_else(||format!("Unknown relation {}", rident))?;
-            let key = relkey_from_record(relid, key)?;
-            Ok(Update::Modify{relid: relid as RelId, k: key, m: Box::new(rec.clone())})
-        }
+/*- !!!!!!!!!!!!!!!!!!!! -*/ // Don't edit this line
+// Code below this point is needed to test-compile template
+// code and is not part of the template.
+
+#[derive(Copy,Clone,Debug)]
+pub enum Relations {
+    X = 0
+}
+
+#[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
+pub enum Value {
+    empty(),
+    bool(bool)
+}
+unsafe_abomonate!(Value);
+
+impl Default for Value {
+    fn default() -> Value {Value::bool(false)}
+}
+impl fmt::Display for Value {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        panic!("Value::fmt not implemented")
     }
 }
 
-fn relident2id(r: &record::RelIdentifier) -> Option<Relations> {
-    match r {
-        record::RelIdentifier::RelName(rname) => relname2id(rname),
-        record::RelIdentifier::RelId(id)      => relid2rel(*id)
+impl IntoRecord for Value {
+    fn into_record(self) -> record::Record {
+        panic!("Value::into_record not implemented")
     }
 }
 
-fn relident2name(r: &record::RelIdentifier) -> Option<&str> {
-    match r {
-        record::RelIdentifier::RelName(rname) => Some(rname.as_ref()),
-        record::RelIdentifier::RelId(id)      => relid2name(*id)
+impl Mutator<Value> for record::Record {
+    fn mutate(&self, _x: &mut Value) -> Result<(), String> {
+        panic!("Value::mutate not implemented")
     }
 }
 
-fn __null_cb(_relid: RelId, _v: &Value, _w: isize) {}
-
-#[no_mangle]
-pub extern "C" fn ddlog_get_table_id(tname: *const raw::c_char) -> libc::size_t
-{
-    if tname.is_null() {
-        return libc::size_t::max_value();
-    };
-    match get_table_id(tname) {
-        Ok(relid) => relid as libc::size_t,
-        Err(e) => {
-            libc::size_t::max_value()
-        }
-    }
+pub fn relname2id(_rname: &str) -> Option<Relations> {
+    panic!("relname2id not implemented")
 }
 
-fn get_table_id(tname: *const raw::c_char) -> Result<Relations, String>
-{
-    let table_str = unsafe{ ffi::CStr::from_ptr(tname) }.to_str().map_err(|e| format!("{}", e))?;
-    relname2id(table_str).ok_or_else(||format!("unknown relation {}", table_str))
+pub fn output_relname_to_id(_rname: &str) -> Option<Relations> {
+    panic!("output_relname_to_id not implemented")
 }
 
-#[no_mangle]
-pub extern "C" fn ddlog_run(
-    workers: raw::c_uint,
-    do_store: bool,
-    cb: Option<extern "C" fn(arg: libc::uintptr_t,
-                             table: libc::size_t,
-                             rec: *const record::Record,
-                             polarity: bool)>,
-    cb_arg:  libc::uintptr_t,
-    print_err: Option<extern "C" fn(msg: *const raw::c_char)>) -> *const HDDlog
-{
-    let workers = if workers == 0 { 1 } else { workers };
-
-    let db: sync::Arc<sync::Mutex<valmap::ValMap>> = sync::Arc::new(sync::Mutex::new(valmap::ValMap::new()));
-    let mut handlers: Vec<Box<dyn handler::DynUpdateHandler<Value>>> = Vec::new();
-    if do_store {
-        handlers.push(Box::new(handler::MTValMapUpdateHandler::new(db.clone())));
-    };
-    match cb {
-        None => {},
-        Some(cb) => handlers.push(Box::new(handler::ExternCUpdateHandler::new(cb, cb_arg)))
-    };
-
-    let handler: Box<dyn handler::DynUpdateHandler<Value>> = if handlers.len() == 0 {
-        Box::new(handler::NullUpdateHandler::new())
-    } else if handlers.len() == 1 {
-        handlers[0].clone()
-    } else {
-        Box::new(handler::ChainedDynUpdateHandler::new(handlers))
-    };
-
-    let program = prog(handler.update());
-    let prog = program.run(workers as usize);
-    sync::Arc::into_raw(sync::Arc::new(HDDlog{
-        prog:           sync::Mutex::new(prog),
-        update_handler: handler,
-        db:             Some(db),
-        print_err:      print_err,
-        replay_file:    None}))
+pub fn input_relname_to_id(_rname: &str) -> Option<Relations> {
+    panic!("input_relname_to_id not implemented")
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_record_commands(prog: *const HDDlog, fd: unix::io::RawFd) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    let mut prog = sync::Arc::from_raw(prog);
-    let res = match sync::Arc::get_mut(&mut prog) {
-        Some(prog) => {
-            /* Swap out the old file and convert it into FD to prevent
-             * the file from closing on destruction (it is the caller's
-             * responsibility to close the file when they're done with it). */
-            let mut old_file = if fd == -1 {
-                None
-            } else {
-                Some(sync::Mutex::new(fs::File::from_raw_fd(fd)))
-            };
-            mem::swap(&mut prog.replay_file, &mut old_file);
-            match old_file {
-                None => (),
-                Some(m) => {
-                    m.into_inner().unwrap().into_raw_fd();
-                }
-            };
-            0
-        },
-        None => -1
-    };
-    sync::Arc::into_raw(prog);
-    res
+pub fn record_update(_file: &mut fs::File, _upd: &record::UpdCmd) {
+    panic!("record_update not implemented")
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_stop(prog: *const HDDlog) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    /* Prevents closing of the old descriptor. */
-    ddlog_record_commands(prog, -1);
-
-    let prog = sync::Arc::from_raw(prog);
-    match sync::Arc::try_unwrap(prog) {
-        Ok(HDDlog{prog, print_err, ..}) => prog.into_inner().map(|p|{p.stop(); 0}).unwrap_or_else(|e|{
-            HDDlog::print_err(print_err, &format!("ddlog_stop(): error acquiring lock: {}", e));
-            -1
-        }),
-        Err(pref) => {
-            pref.eprintln("ddlog_stop(): cannot extract value from Arc");
-            -1
-        }
-    }
+pub fn relid2rel(_rid: RelId) -> Option<Relations> {
+    panic!("relid2rel not implemented")
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_transaction_start(prog: *const HDDlog) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_transaction_start(&prog);
-
-    let res = prog.prog.lock().unwrap().transaction_start().map(|_|0).unwrap_or_else(|e|{
-        prog.eprintln(&format!("ddlog_transaction_start(): error: {}", e));
-        -1
-    });
-    sync::Arc::into_raw(prog);
-    res
+pub fn relval_from_record(_rel: Relations, _rec: &record::Record) -> Result<Value, String> {
+    panic!("relval_from_record not implemented")
 }
 
-unsafe fn record_transaction_start(prog: &sync::Arc<HDDlog>) {
-    if let Some(ref f) = prog.replay_file {
-        if write!(f.lock().unwrap(), "start;\n").is_err() {
-            prog.eprintln("ddlog_transaction_start(): failed to record invocation in replay file");
-        }
-    }
+pub fn relkey_from_record(_rel: Relations, _rec: &record::Record) -> Result<Value, String> {
+    panic!("relkey_from_record not implemented")
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_transaction_commit(prog: *const HDDlog) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_transaction_commit(&prog);
-    prog.update_handler.before_commit();
-
-    let res = prog.prog.lock().unwrap().transaction_commit().map(|_|0).unwrap_or_else(|e|{
-        prog.update_handler.after_commit(false);
-        prog.eprintln(&format!("ddlog_transaction_commit(): error: {}", e));
-        -1
-    });
-    prog.update_handler.after_commit(true);
-    sync::Arc::into_raw(prog);
-    res
+pub fn relid2name(_rid: RelId) -> Option<&'static str> {
+    panic!("relid2name not implemented")
 }
 
-unsafe fn record_transaction_commit(prog: &sync::Arc<HDDlog>) {
-    if let Some(ref f) = prog.replay_file {
-        if write!(f.lock().unwrap(), "commit;\n").is_err() {
-            prog.eprintln("ddlog_transaction_commit(): failed to record invocation in replay file");
-        }
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_transaction_rollback(prog: *const HDDlog) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_transaction_rollback(&prog);
-
-    let res = prog.prog.lock().unwrap().transaction_rollback().map(|_|0).unwrap_or_else(|e|{
-        prog.eprintln(&format!("ddlog_transaction_rollback(): error: {}", e));
-        -1
-    });
-    sync::Arc::into_raw(prog);
-    res
-}
-
-unsafe fn record_transaction_rollback(prog: &sync::Arc<HDDlog>) {
-    if let Some(ref f) = prog.replay_file {
-        if write!(f.lock().unwrap(), "rollback;\n").is_err() {
-            prog.eprintln("ddlog_transaction_rollback(): failed to record invocation in replay file");
-        }
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_apply_updates(prog: *const HDDlog, upds: *const *mut record::UpdCmd, n: size_t) -> raw::c_int
-{
-    if prog.is_null() || upds.is_null() {
-        return -1;
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_updates(&prog, upds, n);
-
-    let mut upds_vec = Vec::with_capacity(n as usize);
-    for i in 0..n {
-        let upd = match updcmd2upd(Box::from_raw(*upds.offset(i as isize)).as_ref()) {
-            Ok(upd) => upd,
-            Err(e) => {
-                prog.eprintln(&format!("ddlog_apply_updates(): invalid argument: {}", e));
-                return -1;
-            }
-        };
-        upds_vec.push(upd);
-    };
-    let res = prog.prog.lock().unwrap().apply_updates(upds_vec).map(|_|0).unwrap_or_else(|e|{
-        prog.eprintln(&format!("ddlog_apply_updates(): error: {}", e));
-        return -1;
-    });
-    sync::Arc::into_raw(prog);
-    res
-}
-
-unsafe fn record_updates(prog: &sync::Arc<HDDlog>, upds: *const *mut record::UpdCmd, n: size_t)
-{
-    if let Some(ref f) = prog.replay_file {
-        let mut file = f.lock().unwrap();
-        for i in 0..n {
-            let sep = if i == n - 1 { ";" } else { "," };
-            record_update(&mut *file, &(**upds.offset(i as isize)));
-            let _ = write!(file, "{}\n", sep);
-        }
-    }
-}
-
-pub fn record_update(file: &mut fs::File, upd: &record::UpdCmd)
-{
-    match upd {
-        record::UpdCmd::Insert(rel, record) => {
-            let _ = write!(file, "insert {}[{}]", relident2name(rel).unwrap_or(&"???"), record);
-        },
-        record::UpdCmd::Delete(rel, record) => {
-            let _ = write!(file, "delete {}[{}]", relident2name(rel).unwrap_or(&"???"), record);
-        },
-        record::UpdCmd::DeleteKey(rel, record) => {
-            let _ = write!(file, "delete_key {} {}", relident2name(rel).unwrap_or(&"???"), record);
-        },
-        record::UpdCmd::Modify(rel, key, mutator) => {
-            let _ = write!(file, "modify {} {} <- {}", relident2name(rel).unwrap_or(&"???"), key, mutator);
-        }
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_clear_relation(
-    prog: *const HDDlog,
-    table: libc::size_t) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_clear_relation(&prog, table);
-
-    let res = match clear_relation(&prog, table) {
-        Ok(()) => { 0 },
-        Err(e) => {
-            prog.eprintln(&format!("ddlog_clear_relation(): error: {}", e));
-            -1
-        }
-    };
-    sync::Arc::into_raw(prog);
-    res
-}
-
-unsafe fn record_clear_relation(prog: &sync::Arc<HDDlog>, table: libc::size_t) {
-    if let Some(ref f) = prog.replay_file {
-        if write!(f.lock().unwrap(), "clear {};\n", relid2name(table).unwrap_or(&"???")).is_err() {
-            prog.eprintln("ddlog_clear_relation(): failed to record invocation in replay file");
-        }
-    }
-}
-
-unsafe fn clear_relation(prog: &HDDlog, table: libc::size_t) -> Result<(), String> {
-    prog.prog.lock().unwrap().clear_relation(table)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_dump_table(
-    prog:    *const HDDlog,
-    table:   libc::size_t,
-    cb:      extern "C" fn(arg: *mut raw::c_void, rec: *const record::Record) -> bool,
-    cb_arg:  *mut raw::c_void) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_dump_table(&prog, table);
-
-    let res = if let Some(ref db) = prog.db {
-        match dump_table(&mut db.lock().unwrap(), table, cb, cb_arg) {
-            Ok(recs) => {
-                0
-            },
-            Err(e) => {
-                prog.eprintln(&format!("ddlog_dump_table(): error: {}", e));
-                -1
-            }
-        }
-    } else {
-        prog.eprintln("ddlog_dump_table(): cannot dump table: ddlog_run() was invoked with do_store flag set to false");
-        -1
-    };
-    sync::Arc::into_raw(prog);
-    res
-}
-
-unsafe fn record_dump_table(prog: &sync::Arc<HDDlog>, table: libc::size_t) {
-    if let Some(ref f) = prog.replay_file {
-        if write!(f.lock().unwrap(), "dump {};\n", relid2name(table).unwrap_or(&"???")).is_err() {
-            prog.eprintln("ddlog_dump_table(): failed to record invocation in replay file");
-        }
-    }
-}
-
-fn dump_table(db: &mut valmap::ValMap,
-              table: libc::size_t,
-              cb: extern "C" fn(arg: *mut raw::c_void, rec: *const record::Record) -> bool,
-              cb_arg: *mut raw::c_void) -> Result<(), String>
-{
-    for val in db.get_rel(table) {
-        if !cb(cb_arg, &val.clone().into_record() as *const record::Record) {
-            break;
-        }
-    };
-    Ok(())
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_enable_cpu_profiling(prog: *const HDDlog, enable: bool) -> raw::c_int
-{
-    if prog.is_null() {
-        return -1;
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_enable_cpu_profiling(&prog, enable);
-
-    prog.prog.lock().unwrap().enable_cpu_profiling(enable);
-    sync::Arc::into_raw(prog);
-    0
-}
-
-fn record_enable_cpu_profiling(prog: &sync::Arc<HDDlog>, enable: bool) {
-    if let Some(ref f) = prog.replay_file {
-        if write!(f.lock().unwrap(), "profile cpu {};\n", if enable { "on" } else { "off" }).is_err() {
-            prog.eprintln("ddlog_cpu_profiling_enable(): failed to record invocation in replay file");
-        }
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ddlog_profile(prog: *const HDDlog) -> *const raw::c_char
-{
-    if prog.is_null() {
-        return ptr::null();
-    };
-    let prog = sync::Arc::from_raw(prog);
-
-    record_profile(&prog);
-
-    let res = {
-        let rprog = prog.prog.lock().unwrap();
-        let profile = format!("{}", rprog.profile.lock().unwrap());
-        ffi::CString::new(profile).expect("Failed to convert profile string to C").into_raw()
-    };
-    sync::Arc::into_raw(prog);
-    res
-}
-
-unsafe fn record_profile(prog: &sync::Arc<HDDlog>) {
-    if let Some(ref f) = prog.replay_file {
-        if write!(f.lock().unwrap(), "profile;\n").is_err() {
-            prog.eprintln("ddlog_profile(): failed to record invocation in replay file");
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn ddlog_string_free(s: *mut raw::c_char)
-{
-    if s.is_null() {
-        return;
-    };
-    unsafe { ffi::CString::from_raw(s); }
+pub fn prog(__update_cb: Box<dyn CBFn<Value>>) -> Program<Value> {
+    panic!("prog not implemented")
 }

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -215,7 +215,7 @@ pub fn main() {
     let deltadb: Arc<Mutex<Option<DeltaMap>>> = Arc::new(Mutex::new(None));
     let deltadb2 = deltadb.clone();
 
-    let handler: Box<dyn IMTUpdateHandler<Value>> = if !store && !print {
+    let handler: Box<dyn IMTUpdateHandler<Value>> = if !store && !print && !delta {
             Box::new(NullUpdateHandler::new())
     } else {
         let handler_generator = move || {

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -225,7 +225,7 @@ pub fn main() {
             };
             handler
         };
-        Box::new(ThreadUpdateHandler::new(handler_generator, 100000))
+        Box::new(ThreadUpdateHandler::new(handler_generator))
     };
 
     let ret = run_interactive(db.clone(), handler, workers);

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -151,7 +151,7 @@ fn is_upd_cmd(c: &Command) -> bool {
     }
 }
 
-pub fn run_interactive(db: Arc<Mutex<ValMap>>, upd_cb: UpdateCallback<Value>, nworkers: usize) -> i32 {
+pub fn run_interactive(db: Arc<Mutex<ValMap>>, upd_cb: Box<dyn CBFn<Value>>, nworkers: usize) -> i32 {
     let p = prog(upd_cb);
     let mut running = Arc::new(Mutex::new(p.run(nworkers)));
     let upds = Arc::new(Mutex::new(Vec::new()));
@@ -185,7 +185,7 @@ pub fn main() {
 
     let db: Arc<Mutex<ValMap>> = Arc::new(Mutex::new(ValMap::new()));
 
-    let ret = run_interactive(db.clone(), Arc::new(move |relid,v,w| {
+    let ret = run_interactive(db.clone(), Box::new(move |relid,v,w| {
         debug_assert!(w == 1 || w == -1);
         upd_cb(print, store, &db, relid, v, w == 1)
     }), workers);

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -66,7 +66,6 @@ fn record_updatecmds(prog: &sync::Arc<HDDlog>, upds: &Vec<UpdCmd>)
             if write!(&mut *file, "{}\n", sep).is_err() {
                 prog.eprintln("ddlog_transaction_start(): failed to record invocation in replay file");
             }
-
         }
     }
 }

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -63,7 +63,10 @@ fn record_updatecmds(prog: &sync::Arc<HDDlog>, upds: &Vec<UpdCmd>)
         for (i, upd) in upds.iter().enumerate() {
             let sep = if i == n - 1 { ";" } else { "," };
             record_update(&mut *file, upd);
-            write!(&mut *file, "{}\n", sep);
+            if write!(&mut *file, "{}\n", sep).is_err() {
+                prog.eprintln("ddlog_transaction_start(): failed to record invocation in replay file");
+            }
+
         }
     }
 }

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -4,13 +4,12 @@ use differential_datalog::program::*;
 use differential_datalog::record::{IntoRecord, UpdCmd};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
-use super::{Value, updcmd2upd, relname2id};
+use super::{Value, relname2id};
 use ddlog_ovsdb_adapter::*;
 use super::valmap;
 use std::sync;
-use std::ptr;
 use std::io::Write;
-use super::{HDDlog, output_relname_to_id, record_update};
+use super::api::{HDDlog, updcmd2upd, record_update};
 
 /// Parse OVSDB JSON <table-updates> value into DDlog commands; apply commands to a DDlog program.
 ///
@@ -150,5 +149,5 @@ fn dump_delta(db: &mut valmap::ValMap, module: *const c_char, table: *const c_ch
 #[no_mangle]
 pub extern "C" fn ddlog_free_json(str: *mut c_char) {
     if str.is_null() { return; }
-    let cstr = unsafe{CString::from_raw(str)};
+    let _ = unsafe{CString::from_raw(str)};
 }

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -18,10 +18,10 @@ use super::api::{HDDlog, updcmd2upd, record_update};
 /// `prefix` contains is the prefix to be added to JSON table names, e.g, `OVN_Southbound_` or
 /// `OVN_Northbound_` for OVN southbound and northbound database updates.
 ///
-/// `updates` is the JSON string, e.g.,
-/// ```
+/// `updates` is the JSON string, e.g.:
+///
 /// {"Logical_Switch":{"ffe8d84e-b4a0-419e-b865-19f151eed878":{"new":{"acls":["set",[]],"dns_records":["set",[]],"external_ids":["map",[]],"load_balancer":["set",[]],"name":"lsw0","other_config":["map",[]],"ports":["set",[]],"qos_rules":["set",[]]}}}}
-/// ```
+///
 ///
 #[no_mangle]
 pub unsafe extern "C" fn ddlog_apply_ovsdb_updates(

--- a/rust/template/update_handler.rs
+++ b/rust/template/update_handler.rs
@@ -1,0 +1,166 @@
+//! `UpdateHandler` trait and its implementations.
+//!
+//! `UpdateHandler` abstracts away different methods of handling
+//! relation update notifications from differential dataflow.
+//! Possible implementations include:
+//! - handling notifications by invoking a user-defined callback
+//! - storing output tables in an in-memory database
+//! - accumulating changes from one or multiple transactions in
+//!   an in-memory database
+//! - chaining multiple update handlers
+//! - all of the above, but processed by a separate thread
+//!   rather than the differential worker threads that computes
+//!   the update
+//! - all of the above, but processed by a pool of worker threads
+
+use super::*;
+
+use std::thread::*;
+use std::sync::mpsc::*;
+
+pub trait UpdateHandler<V>: Send {
+    /* Invoked on each output relation update */
+    fn update(&self, relid: RelId, v: &V, w: bool);
+
+    /* Notifies the handler that a transaction_commit method is about to be
+     * called. The handler has an opportunity to prepare to handle
+     * update notifications. */
+    fn before_commit(&self);
+
+    /* Notifies the handler that transaction_commit has finished.  The
+     * `success` flag indicates whether the commit succeeded or failed. */
+    fn after_commit(&self, success: bool);
+}
+
+/* Multi-threaded update handler that can be invoked from multiple DDlog
+ * worker threads.
+ */
+pub trait MTUpdateHandler<V>: UpdateHandler<V> + Sync {}
+impl <V: Val, H: UpdateHandler<V> + Sync + Send> MTUpdateHandler<V> for H {}
+
+type ExternCCallback = extern "C" fn(arg: libc::uintptr_t,
+                                     table: libc::size_t,
+                                     rec: *const record::Record,
+                                     polarity: bool);
+
+/* Rust magic to make `MTUpdateHandler` clonable.
+ */
+pub trait DynUpdateHandler<V>: MTUpdateHandler<V> {
+   fn clone_boxed(&self) -> Box<dyn DynUpdateHandler<V>>;
+}
+
+impl<T, V> DynUpdateHandler<V> for T
+where
+   T: MTUpdateHandler<V> + Clone + 'static
+{
+   fn clone_boxed(&self) -> Box<dyn DynUpdateHandler<V>> {
+       Box::new(self.clone())
+   }
+}
+
+impl<V> Clone for Box<dyn DynUpdateHandler<V>> {
+   fn clone(&self) -> Self {
+       self.as_ref().clone_boxed()
+   }
+}
+
+/* A no-op `UpdateHandler` implementation
+ */
+#[derive(Clone)]
+pub struct NullUpdateHandler {}
+
+impl NullUpdateHandler
+{
+    pub fn new() -> Self {
+        Self{}
+    }
+}
+
+impl <V: Val> UpdateHandler<V> for NullUpdateHandler
+{
+    fn update(&self, _relid: RelId, _v: &V, _w: bool) {}
+    fn before_commit(&self) {}
+    fn after_commit(&self, _success: bool) {}
+}
+
+/* `UpdateHandler` implementation that invokes user-provided callback.
+ */
+#[derive(Clone)]
+pub struct ExternCUpdateHandler {
+    cb:      ExternCCallback,
+    cb_arg:  libc::uintptr_t
+}
+
+impl ExternCUpdateHandler
+{
+    pub fn new(cb: ExternCCallback, cb_arg: libc::uintptr_t) -> Self {
+        Self{cb, cb_arg}
+    }
+}
+
+impl <V: Val + IntoRecord> UpdateHandler<V> for ExternCUpdateHandler
+{
+    fn update(&self, relid: RelId, v: &V, w: bool) {
+        (self.cb)(self.cb_arg, relid, &v.clone().into_record() as *const record::Record, w)
+    }
+    fn before_commit(&self) {}
+    fn after_commit(&self, success: bool) {}
+}
+
+/* Multi-threaded `UpdateHandler` implementation that stores updates
+ * in a `ValMap` and locks the map on every update.
+ */
+#[derive(Clone)]
+pub struct MTValMapUpdateHandler {
+    db: sync::Arc<sync::Mutex<valmap::ValMap>>
+}
+
+impl MTValMapUpdateHandler
+{
+    pub fn new(db: sync::Arc<sync::Mutex<valmap::ValMap>>) -> Self {
+        Self{db}
+    }
+}
+
+impl UpdateHandler<Value> for MTValMapUpdateHandler
+{
+    fn update(&self, relid: RelId, v: &Value, w: bool) {
+        self.db.lock().unwrap().update(relid, v, w)
+    }
+    fn before_commit(&self) {}
+    fn after_commit(&self, success: bool) {}
+}
+
+/* `UpdateHandler` implementation that chains multiple multi-threaded
+ * handlers.
+ */
+#[derive(Clone)]
+pub struct ChainedDynUpdateHandler<V: Val> {
+    handlers: Vec<Box<dyn DynUpdateHandler<V>>>
+}
+
+impl <V: Val> ChainedDynUpdateHandler<V> {
+    pub fn new(handlers: Vec<Box<dyn DynUpdateHandler<V>>>) -> Self {
+        Self{handlers}
+    }
+}
+
+impl <V: Val> UpdateHandler<V> for ChainedDynUpdateHandler<V>
+{
+    fn update(&self, relid: RelId, v: &V, w: bool) {
+        for h in self.handlers.iter() {
+            h.update(relid, v, w);
+        }
+    }
+    fn before_commit(&self) {
+        for h in self.handlers.iter() {
+            h.before_commit();
+        }
+    }
+
+    fn after_commit(&self, success: bool) {
+        for h in self.handlers.iter() {
+            h.after_commit(success);
+        }
+    }
+}

--- a/rust/template/update_handler.rs
+++ b/rust/template/update_handler.rs
@@ -349,6 +349,8 @@ enum Msg<V: Val> {
     Stop
 }
 
+
+
 #[derive(Clone)]
 pub struct ThreadUpdateHandler<V: Val> {
     /* Channel to worker thread. */
@@ -360,7 +362,15 @@ pub struct ThreadUpdateHandler<V: Val> {
 
 impl <V: Val> ThreadUpdateHandler<V>
 {
-    pub fn new<F>(handler_generator: F, queue_capacity: usize) -> Self 
+    pub const DEFAULT_QUEUE_CAPACITY: usize = 100000;
+
+    pub fn new<F>(handler_generator: F) -> Self
+        where F: FnOnce() -> Box<dyn UpdateHandler<V>> + Send + 'static
+    {
+        Self::with_capacity(handler_generator, Self::DEFAULT_QUEUE_CAPACITY)
+    }
+
+    pub fn with_capacity<F>(handler_generator: F, queue_capacity: usize) -> Self 
         where F: FnOnce() -> Box<dyn UpdateHandler<V>> + Send + 'static
     {
         let (tx_msg_channel, rx_message_channel) = sync_channel(queue_capacity);

--- a/rust/template/valmap.rs
+++ b/rust/template/valmap.rs
@@ -63,6 +63,13 @@ impl DeltaMap {
         DeltaMap{map: BTreeMap::default()}
     }
 
+    pub fn as_ref(&self) -> &BTreeMap<RelId, BTreeMap<Value, isize>> {
+        &self.map
+    }
+    pub fn as_mut(&mut self) -> &mut BTreeMap<RelId, BTreeMap<Value, isize>> {
+        &mut self.map
+    }
+
     pub fn format(&self, w: &mut io::Write) -> io::Result<()> {
        for (relid, relmap) in &self.map {
            w.write_fmt(format_args!("{:?}:\n", relid2rel(*relid).unwrap()))?;

--- a/rust/template/valmap.rs
+++ b/rust/template/valmap.rs
@@ -6,55 +6,37 @@
 
 use std::io;
 
-use std::collections::BTreeMap;
+use std::collections::btree_map::{BTreeMap, Entry};
 use std::collections::BTreeSet;
 
 use super::*;
 
+/* Stores the snapshot of output tables.
+ */
 pub struct ValMap{map: BTreeMap<RelId, BTreeSet<Value>>}
-
-#[no_mangle]
-pub fn val_map_new() -> *mut ValMap {
-    Box::into_raw(Box::new(ValMap::new()))
-}
-
-#[no_mangle]
-pub fn val_map_print(map: *mut ValMap) {
-    let map = unsafe{&mut *map};
-    map.format(&mut io::stdout());
-}
-
-#[no_mangle]
-pub fn val_map_print_rel(map: *mut ValMap, relid: RelId) {
-    let map = unsafe{&mut *map};
-    map.format_rel(relid, &mut io::stdout());
-}
-
-#[no_mangle]
-pub fn val_map_free(map: *mut ValMap) {
-    unsafe{Box::from_raw(map);}
-}
 
 impl ValMap {
     pub fn new() -> ValMap {
         ValMap{map: BTreeMap::default()}
     }
 
-    pub fn format(&self, w: &mut io::Write) {
+    pub fn format(&self, w: &mut io::Write) -> io::Result<()> {
        for (relid, relset) in &self.map {
-           w.write_fmt(format_args!("{:?}:\n", relid2rel(*relid).unwrap()));
+           w.write_fmt(format_args!("{:?}:\n", relid2rel(*relid).unwrap()))?;
            for val in relset {
-                w.write_fmt(format_args!("{}\n", *val));
+                w.write_fmt(format_args!("{}\n", *val))?;
            };
-           w.write_fmt(format_args!("\n"));
+           w.write_fmt(format_args!("\n"))?;
        };
+       Ok(())
     }
 
-    pub fn format_rel(&mut self, relid: RelId, w: &mut io::Write) {
+    pub fn format_rel(&mut self, relid: RelId, w: &mut io::Write) -> io::Result<()> {
         let set = self.get_rel(relid);
         for val in set {
-            w.write_fmt(format_args!("{}\n", *val));
+            w.write_fmt(format_args!("{}\n", *val))?;
         };
+        Ok(())
     }
 
     pub fn get_rel(&mut self, relid: RelId) -> &BTreeSet<Value> {
@@ -69,5 +51,56 @@ impl ValMap {
         } else {
             self.map.entry(relid).or_insert(BTreeSet::default()).remove(x);
         }
+    }
+}
+
+/* Stores a set of changes to output tables.
+ */
+pub struct DeltaMap{map: BTreeMap<RelId, BTreeMap<Value, isize>>}
+
+impl DeltaMap {
+    pub fn new() -> DeltaMap {
+        DeltaMap{map: BTreeMap::default()}
+    }
+
+    pub fn format(&self, w: &mut io::Write) -> io::Result<()> {
+       for (relid, relmap) in &self.map {
+           w.write_fmt(format_args!("{:?}:\n", relid2rel(*relid).unwrap()))?;
+           for (val, weight) in relmap {
+                w.write_fmt(format_args!("{}: {}\n", *val, *weight))?;
+           };
+           w.write_fmt(format_args!("\n"))?;
+       };
+       Ok(())
+    }
+
+    pub fn format_rel(&mut self, relid: RelId, w: &mut io::Write) -> io::Result<()> {
+        let map = self.get_rel(relid);
+        for (val, weight) in map {
+            w.write_fmt(format_args!("{}: {}\n", *val, *weight))?;
+        };
+        Ok(())
+    }
+
+    pub fn get_rel(&mut self, relid: RelId) -> &BTreeMap<Value, isize> {
+        self.map.entry(relid).or_insert(BTreeMap::default())
+    }
+
+    pub fn update(&mut self, relid: RelId, x : &Value, insert: bool)
+    {
+        let diff = if insert { 1 } else { -1 };
+        //println!("set_update({}) {:?} {}", rel, *x, insert);
+        let entry = self.map.entry(relid).or_insert(BTreeMap::default())
+                        .entry(x.clone());
+        match entry {
+            Entry::Vacant(vacant) => { vacant.insert(diff); },
+            Entry::Occupied(mut occupied) => {
+                if *occupied.get() == -diff {
+                    occupied.remove();
+                } else {
+                    *occupied.get_mut() += diff;
+                }
+            }
+        };
     }
 }

--- a/rust/template/valmap.rs
+++ b/rust/template/valmap.rs
@@ -53,7 +53,7 @@ impl ValMap {
     pub fn format_rel(&mut self, relid: RelId, w: &mut io::Write) {
         let set = self.get_rel(relid);
         for val in set {
-            println!("{}", *val);
+            w.write_fmt(format_args!("{}\n", *val));
         };
     }
 

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -131,6 +131,7 @@ templateFiles specname =
         , (dir </> "main.rs"                , $(embedFile "rust/template/main.rs"))
         , (dir </> "ovsdb.rs"               , $(embedFile "rust/template/ovsdb.rs"))
         , (dir </> "valmap.rs"              , $(embedFile "rust/template/valmap.rs"))
+        , (dir </> "update_handler.rs"      , $(embedFile "rust/template/update_handler.rs"))
         , (dir </> "ddlog.h"                , $(embedFile "rust/template/ddlog.h"))
         , (dir </> "ddlog_ovsdb_test.c"     , $(embedFile "rust/template/ddlog_ovsdb_test.c"))
         ]
@@ -1032,7 +1033,7 @@ compileRelation d rn = do
                 relPrimaryKey
 
     let cb = if relRole == RelOutput
-                then "change_cb:    Some(__update_cb.clone())"
+                then "change_cb:    Some(sync::Arc::new(sync::Mutex::new(__update_cb.clone())))"
                 else "change_cb:    None"
     arrangements <- gets $ (M.! rn) . cArrangements
     compiled_arrangements <- mapM (mkArrangement d rel) arrangements
@@ -1714,7 +1715,7 @@ mkProg d nodes = do
                "    ]"                                          $$
                "}"
     return $
-        "pub fn prog(__update_cb: UpdateCallback<Value>) -> Program<Value> {"  $$
+        "pub fn prog(__update_cb: Box<dyn CBFn<Value>>) -> Program<Value> {"  $$
         (nest' $ rels $$ prog)                                                 $$
         "}"
 

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -49,6 +49,7 @@ import Data.Int
 import Data.Word
 import Data.Bits hiding (isSigned)
 import Data.Char
+import Data.List.Split
 import Data.FileEmbed
 import Data.String.Utils
 import System.FilePath
@@ -111,7 +112,12 @@ fUNCS_RETURN_REF = ["std.deref"]
 
 -- Rust imports
 header :: String -> Doc
-header specname = pp $ replace "datalog_example" specname $ BS.unpack $ $(embedFile "rust/template/lib.rs")
+header specname =
+    let h = case splitOn "/*- !!!!!!!!!!!!!!!!!!!! -*/" 
+                 $ BS.unpack $ $(embedFile "rust/template/lib.rs") of
+                []  -> error "Missing separator in lib.rs"
+                h:_ -> h
+    in pp $ replace "datalog_example" specname h
 
 -- Cargo.toml
 cargo :: String -> Doc -> [String] -> Doc
@@ -129,6 +135,7 @@ templateFiles specname =
     map (mapSnd (BS.unpack)) $
         [ (dir </> "build.rs"               , $(embedFile "rust/template/build.rs"))
         , (dir </> "main.rs"                , $(embedFile "rust/template/main.rs"))
+        , (dir </> "api.rs"                 , $(embedFile "rust/template/api.rs"))
         , (dir </> "ovsdb.rs"               , $(embedFile "rust/template/ovsdb.rs"))
         , (dir </> "valmap.rs"              , $(embedFile "rust/template/valmap.rs"))
         , (dir </> "update_handler.rs"      , $(embedFile "rust/template/update_handler.rs"))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -83,7 +83,7 @@ goldenTests progress = do
   let compiler_tests = testGroup "compiler tests" $ catMaybes $
           [ if shouldFail $ file
                then Nothing
-               else Just $ goldenVsFiles (takeBaseName file) expect output (compilerTest progress file [] ["staticlib", "cdylib"])
+               else Just $ goldenVsFiles (takeBaseName file) expect output (compilerTest progress file [] ["staticlib"])
             | file:files <- inFiles
             , let expect = map (uncurry replaceExtension) $ zip files [".dump.expected"]
             , let output = map (uncurry replaceExtension) $ zip files [".dump"]]

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -11,7 +11,7 @@ insert Links(1, "Louvres", "Palais Royal"),
 insert Links(1, "Palais-Royal", "Tuileries"),
 insert Links(1, "Tuileries", "Concorde");
 
-commit;
+commit dump_changes;
 
 dump;
 
@@ -24,7 +24,7 @@ insert R3(3, true),
 insert R3(4, true),
 insert R3(5, true),
 insert R3(6, true);
-commit;
+commit dump_changes;
 dump;
 
 start;
@@ -36,7 +36,7 @@ insert Table2("foo", 1234567890, S{(true,true),5}),
 insert Table2("foo", 12, S{(true,false),0xabcd}),
 insert Table2("foo", 100000000000000, S{(false,true),10000}),
 insert Table2("buzzzzzzzz", 1234567890, S{(true,true),5});
-commit;
+commit dump_changes;
 dump Table12;
 
 start;
@@ -45,7 +45,7 @@ insert Rel1(0, IP4{100}),
 insert Rel1(1, IP6{200}),
 insert Rel2(0, Option1{0, IP4{300}, (true, "foo")});
 
-commit;
+commit dump_changes;
 
 echo Rel3:;
 dump Rel3;
@@ -66,7 +66,7 @@ insert AggregateMe3("b", "1", "z"),
 insert AggregateMe3("b", "2", "z"),
 insert AggregateMe3("b", "3", "z");
 
-commit;
+commit dump_changes;
 
 echo Aggregate1;
 dump Aggregate1;
@@ -104,7 +104,7 @@ insert AggregateMeInts("b", 10),
 insert AggregateMeInts("b", 20),
 insert AggregateMeInts("b", 30);
 
-commit;
+commit dump_changes;
 
 echo Sum;
 dump Sum;
@@ -116,7 +116,7 @@ insert WithKey(0, "foo"),
 insert WithKey(1, "bar"),
 insert WithKey(2, "buzz");
 
-commit;
+commit dump_changes;
 
 echo WithKeyDbg;
 dump WithKeyDbg;
@@ -125,7 +125,7 @@ start;
 
 delete WithKey(0, "foo");
 
-commit;
+commit dump_changes;
 
 echo WithKeyDbg after deletion by value;
 dump WithKeyDbg;
@@ -134,7 +134,7 @@ start;
 
 delete_key WithKey 1;
 
-commit;
+commit dump_changes;
 
 echo WithKeyDbg after deletion by key;
 dump WithKeyDbg;
@@ -148,7 +148,7 @@ insert WithKey(4, "hello"),
 delete_key WithKey 2,
 delete_key WithKey 3;
 
-commit;
+commit dump_changes;
 
 echo WithKeyDbg: +3, -2;
 dump WithKeyDbg;
@@ -178,7 +178,7 @@ insert Suspect("Bill Smith"),
 insert Suspect("Arnold Squitieri"),
 insert Suspect("Frank Morelli");
 
-commit;
+commit dump_changes;
 
 echo Innocent;
 dump Innocent;
@@ -199,7 +199,7 @@ insert Address(IPAddr{192,168,0,5}),
 insert Blacklist(IPAddr{192,168,0,0}),
 insert Blacklist(IPAddr{172,16,0,0});
 
-commit;
+commit dump_changes;
 
 echo ValidDestination;
 dump ValidDestination;
@@ -208,7 +208,7 @@ start;
 insert HostAddresses(0, ["10.10.10.101", "10.10.10.102", "10.10.10.103"]),
 insert HostAddresses(0, ["10.10.10.103", "10.10.10.104", "10.10.10.105"]),
 insert HostAddresses(1, ["192.168.0.1", "192.168.0.2", "192.168.0.3"]);
-commit;
+commit dump_changes;
 
 dump HostAddress;
 
@@ -217,7 +217,7 @@ start;
 
 insert ExternalIds(0, [("a", "1"),("b", "2"),("c", "3")]),
 insert ExternalIds(0, [("c", "4"),("d", "5"),("e", "6")]);
-commit;
+commit dump_changes;
 
 dump ExternalId;
 
@@ -242,7 +242,7 @@ insert Request("b", "3"),
 insert Request("b", "4"),
 insert Request("b", "5");
 
-commit;
+commit dump_changes;
 
 dump Allocation;
 
@@ -251,7 +251,7 @@ start;
 clear Request;
 clear Realized;
 
-commit;
+commit dump_changes;
 
 echo Allocation after clear;
 dump Allocation;
@@ -260,7 +260,7 @@ start;
 
 insert Referenced(true, std.Some{"hello"});
 
-commit;
+commit dump_changes;
 
 echo Referee;
 dump Referee;
@@ -414,7 +414,7 @@ insert Alloc(.id = 21,
              .min_val = 1,
              .max_val = 1),
 
-commit;
+commit dump_changes;
 
 echo NewAllocation;
 dump NewAllocation;
@@ -437,7 +437,7 @@ insert YZX(.y = 30, .z = 300, .x = 3),
 insert YZX(.y = 40, .z = 400, .x = 4),
 insert YZX(.y = 50, .z = 500, .x = 5);
 
-commit;
+commit dump_changes;
 
 echo YX;
 dump YX;
@@ -458,7 +458,7 @@ insert Edge(7,8),
 insert Edge(0,7),
 insert Edge(11,12);
 
-commit;
+commit dump_changes;
 
 echo SCCLabel;
 dump SCCLabel;
@@ -471,7 +471,7 @@ insert IString1("Foo "),
 insert String2("world"),
 insert String2("bar");
 
-commit;
+commit dump_changes;
 
 echo ConcatString;
 dump ConcatString;
@@ -491,7 +491,7 @@ insert AMethod("foo", "buzz"),
 insert BMethod("c", "world"),
 insert AMethod("world", "hello"),
 
-commit;
+commit dump_changes;
 
 echo CMethod;
 dump CMethod;
@@ -507,7 +507,7 @@ insert Numbers(2),
 insert Numbers(3),
 insert Numbers(4);
 
-commit;
+commit dump_changes;
 
 echo Power3;
 dump Power3;
@@ -523,7 +523,7 @@ insert Regex("(?i)a+(?-i)b+", "AaAaAbbBBBb"),
 insert Regex("a+b+", "aaaaabbbbbb"),
 insert Regex("a+b+", "AaAaAbbBBBb"),
 
-commit;
+commit dump_changes;
 
 echo RegexMatch;
 dump RegexMatch;

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -1,5 +1,47 @@
 Metro test
 Answer:
+Answer{"Chatelet"}: 1
+Answer{"Louvres"}: 1
+Answer{"Odeon"}: 1
+Answer{"Palais Royal"}: 1
+Answer{"St.Germain"}: 1
+Answer{"St.Michel"}: 1
+
+Reach:
+Reach{"Chatelet","Chatelet"}: 1
+Reach{"Chatelet","Louvres"}: 1
+Reach{"Chatelet","Palais Royal"}: 1
+Reach{"Chatelet","St.Michel"}: 1
+Reach{"Concorde","Tuileries"}: 1
+Reach{"Louvres","Chatelet"}: 1
+Reach{"Louvres","Louvres"}: 1
+Reach{"Louvres","Palais Royal"}: 1
+Reach{"Odeon","Chatelet"}: 1
+Reach{"Odeon","Louvres"}: 1
+Reach{"Odeon","Odeon"}: 1
+Reach{"Odeon","Palais Royal"}: 1
+Reach{"Odeon","St.Germain"}: 1
+Reach{"Odeon","St.Michel"}: 1
+Reach{"Palais Royal","Louvres"}: 1
+Reach{"Palais-Royal","Concorde"}: 1
+Reach{"Palais-Royal","Palais-Royal"}: 1
+Reach{"Palais-Royal","Tuileries"}: 1
+Reach{"St.Germain","Chatelet"}: 1
+Reach{"St.Germain","Louvres"}: 1
+Reach{"St.Germain","Odeon"}: 1
+Reach{"St.Germain","Palais Royal"}: 1
+Reach{"St.Germain","St.Germain"}: 1
+Reach{"St.Germain","St.Michel"}: 1
+Reach{"St.Michel","Chatelet"}: 1
+Reach{"St.Michel","Louvres"}: 1
+Reach{"St.Michel","Odeon"}: 1
+Reach{"St.Michel","Palais Royal"}: 1
+Reach{"St.Michel","St.Michel"}: 1
+Reach{"Tuileries","Concorde"}: 1
+Reach{"Tuileries","Palais-Royal"}: 1
+Reach{"Tuileries","Tuileries"}: 1
+
+Answer:
 Answer{"Chatelet"}
 Answer{"Louvres"}
 Answer{"Odeon"}
@@ -153,6 +195,33 @@ UMinus_s32{"-32'sd100",-100}
 UMinus_s32{"-32768",-32768}
 
 Rules test
+R4:
+R3{0,true}: 1
+R3{1,true}: 1
+R3{2,true}: 1
+R3{3,true}: 1
+R3{4,true}: 1
+R3{5,true}: 1
+R3{6,true}: 1
+
+R5:
+0: 1
+1: 1
+2: 1
+3: 1
+4: 1
+5: 1
+6: 1
+
+R6:
+R6{0}: 1
+R6{1}: 1
+R6{2}: 1
+R6{3}: 1
+R6{4}: 1
+R6{5}: 1
+R6{6}: 1
+
 Answer:
 Answer{"Chatelet"}
 Answer{"Louvres"}
@@ -333,6 +402,18 @@ UMinus_s32{"-(-32'sd100)",100}
 UMinus_s32{"-32'sd100",-100}
 UMinus_s32{"-32768",-32768}
 
+Table12:
+Table12{20695836920908937261915266253713563738,"foo",S{(true, true),5}}: 1
+Table12{81692126345696542188923640651411714412,"foo",S{(false, true),10000}}: 1
+Table12{137151609739491206170748566711757625861,"foo",S{(true, false),43981}}: 1
+Table12{173592105249357153805573863620167017533,"foo",S{(false, true),10000}}: 1
+Table12{173670172741911619502105830072953828992,"foo",S{(true, false),43981}}: 1
+Table12{211727904196777888792921590151204575764,"foo",S{(true, true),5}}: 1
+Table12{218334107078988268330177571792522447425,"foo",S{(true, true),5}}: 1
+Table12{258101594679877739861006822360175003366,"buzzzzzzzz",S{(true, true),5}}: 1
+Table12{312560568469280405643575197132576203606,"foo",S{(false, true),10000}}: 1
+Table12{324905179504175058909924909437678210347,"foo",S{(true, false),43981}}: 1
+
 Table12{20695836920908937261915266253713563738,"foo",S{(true, true),5}}
 Table12{81692126345696542188923640651411714412,"foo",S{(false, true),10000}}
 Table12{137151609739491206170748566711757625861,"foo",S{(true, false),43981}}
@@ -344,7 +425,47 @@ Table12{258101594679877739861006822360175003366,"buzzzzzzzz",S{(true, true),5}}
 Table12{312560568469280405643575197132576203606,"foo",S{(false, true),10000}}
 Table12{324905179504175058909924909437678210347,"foo",S{(true, false),43981}}
 Rel3:
+Rel3{0,IP4{100},Option1{0,IP4{300},(true, "foo")}}: 1
+
+Rel3:
 Rel3{0,IP4{100},Option1{0,IP4{300},(true, "foo")}}
+Aggregate1:
+Aggregate1{"a",3}: 1
+Aggregate1{"b",3}: 1
+
+Aggregate2:
+Aggregate2{"a",std_Set { x: {"1", "2", "3"} }}: 1
+Aggregate2{"b",std_Set { x: {"1", "2", "3"} }}: 1
+
+Aggregate3:
+Aggregate3{"a",std_Vec { x: ["1", "2", "3"] }}: 1
+Aggregate3{"b",std_Vec { x: ["1", "2", "3"] }}: 1
+
+Aggregate4:
+Aggregate4{"a",std_Map { x: {"a": "3"} }}: 1
+Aggregate4{"b",std_Map { x: {"b": "3"} }}: 1
+
+AggregateByX:
+AggregateByX{"a",3}: 1
+AggregateByX{"b",3}: 1
+
+AggregateCnt:
+AggregateCnt{6}: 1
+
+AggregateCnt2:
+AggregateCnt2{6}: 1
+
+AggregateCnt3:
+AggregateCnt3{4}: 1
+
+Disaggregate:
+Disaggregate{"a","1"}: 1
+Disaggregate{"a","2"}: 1
+Disaggregate{"a","3"}: 1
+Disaggregate{"b","1"}: 1
+Disaggregate{"b","2"}: 1
+Disaggregate{"b","3"}: 1
+
 Aggregate1
 Aggregate1{"a",3}
 Aggregate1{"b",3}
@@ -373,30 +494,71 @@ Disaggregate{"a","3"}
 Disaggregate{"b","1"}
 Disaggregate{"b","2"}
 Disaggregate{"b","3"}
+Sum:
+Sum{"a",111}: 1
+Sum{"b",60}: 1
+
 Sum
 Sum{"a",111}
 Sum{"b",60}
+WithKeyDbg:
+WithKeyDbg{0,"foo"}: 1
+WithKeyDbg{1,"bar"}: 1
+WithKeyDbg{2,"buzz"}: 1
+
 WithKeyDbg
 WithKeyDbg{0,"foo"}
 WithKeyDbg{1,"bar"}
 WithKeyDbg{2,"buzz"}
+WithKeyDbg:
+WithKeyDbg{0,"foo"}: -1
+
 WithKeyDbg after deletion by value
 WithKeyDbg{1,"bar"}
 WithKeyDbg{2,"buzz"}
+WithKeyDbg:
+WithKeyDbg{1,"bar"}: -1
+
 WithKeyDbg after deletion by key
 WithKeyDbg{2,"buzz"}
+WithKeyDbg:
+WithKeyDbg{1,"bar2"}: 1
+WithKeyDbg{2,"buzz"}: -1
+WithKeyDbg{4,"hello"}: 1
+
 WithKeyDbg: +3, -2
 WithKeyDbg{1,"bar2"}
 WithKeyDbg{4,"hello"}
+Innocent:
+Innocent{"Bill Smith"}: 1
+Innocent{"John Doe"}: 1
+
 Innocent
 Innocent{"Bill Smith"}
 Innocent{"John Doe"}
+ValidDestination:
+ValidDestination{IPAddr{10,10,10,101}}: 1
+ValidDestination{IPAddr{10,10,10,102}}: 1
+ValidDestination{IPAddr{10,10,10,103}}: 1
+ValidDestination{IPAddr{10,10,10,104}}: 1
+ValidDestination{IPAddr{10,10,10,105}}: 1
+
 ValidDestination
 ValidDestination{IPAddr{10,10,10,101}}
 ValidDestination{IPAddr{10,10,10,102}}
 ValidDestination{IPAddr{10,10,10,103}}
 ValidDestination{IPAddr{10,10,10,104}}
 ValidDestination{IPAddr{10,10,10,105}}
+HostAddress:
+HostAddress{0,"10.10.10.101"}: 1
+HostAddress{0,"10.10.10.102"}: 1
+HostAddress{0,"10.10.10.103"}: 1
+HostAddress{0,"10.10.10.104"}: 1
+HostAddress{0,"10.10.10.105"}: 1
+HostAddress{1,"192.168.0.1"}: 1
+HostAddress{1,"192.168.0.2"}: 1
+HostAddress{1,"192.168.0.3"}: 1
+
 HostAddress{0,"10.10.10.101"}
 HostAddress{0,"10.10.10.102"}
 HostAddress{0,"10.10.10.103"}
@@ -405,12 +567,31 @@ HostAddress{0,"10.10.10.105"}
 HostAddress{1,"192.168.0.1"}
 HostAddress{1,"192.168.0.2"}
 HostAddress{1,"192.168.0.3"}
+ExternalId:
+ExternalId{0,("a", "1")}: 1
+ExternalId{0,("b", "2")}: 1
+ExternalId{0,("c", "3")}: 1
+ExternalId{0,("c", "4")}: 1
+ExternalId{0,("d", "5")}: 1
+ExternalId{0,("e", "6")}: 1
+
 ExternalId{0,("a", "1")}
 ExternalId{0,("b", "2")}
 ExternalId{0,("c", "3")}
 ExternalId{0,("c", "4")}
 ExternalId{0,("d", "5")}
 ExternalId{0,("e", "6")}
+Allocation:
+Allocation{"a","1",30}: 1
+Allocation{"a","2",31}: 1
+Allocation{"a","3",50}: 1
+Allocation{"a","4",51}: 1
+Allocation{"a","5",52}: 1
+Allocation{"b","1",10000}: 1
+Allocation{"b","3",16777215}: 1
+Allocation{"b","4",1}: 1
+Allocation{"b","5",2}: 1
+
 Allocation{"a","1",30}
 Allocation{"a","2",31}
 Allocation{"a","3",50}
@@ -420,7 +601,30 @@ Allocation{"b","1",10000}
 Allocation{"b","3",16777215}
 Allocation{"b","4",1}
 Allocation{"b","5",2}
+Allocation:
+Allocation{"a","1",30}: -1
+Allocation{"a","2",31}: -1
+Allocation{"a","3",50}: -1
+Allocation{"a","4",51}: -1
+Allocation{"a","5",52}: -1
+Allocation{"b","1",10000}: -1
+Allocation{"b","3",16777215}: -1
+Allocation{"b","4",1}: -1
+Allocation{"b","5",2}: -1
+
 Allocation after clear
+Filtered:
+Filtered{Referenced{true,std.Some{"hello"}}}: 1
+
+Filtered2:
+Filtered2{Referee2{Referenced{true,std.Some{"hello"}}}}: 1
+
+Referee:
+Referee{Referenced{true,std.Some{"hello"}}}: 1
+
+Referee2:
+Referee2{Referenced{true,std.Some{"hello"}}}: 1
+
 Referee
 Referee{Referenced{true,std.Some{"hello"}}}
 Filtered
@@ -429,6 +633,78 @@ Referee2
 Referee2{Referenced{true,std.Some{"hello"}}}
 Filtered2
 Filtered2{Referee2{Referenced{true,std.Some{"hello"}}}}
+Adjusted:
+Adjusted{1,std_Vec { x: [] }}: 1
+Adjusted{2,std_Vec { x: [("a", 0)] }}: 1
+Adjusted{3,std_Vec { x: [("a", 0)] }}: 1
+Adjusted{4,std_Vec { x: [("a", 0), ("b", 1)] }}: 1
+Adjusted{5,std_Vec { x: [("a", 1000), ("b", 1001)] }}: 1
+Adjusted{5,std_Vec { x: [("a", 4294967294), ("b", 4294967295)] }}: 1
+Adjusted{6,std_Vec { x: [("a", 4294967292), ("b", 4294967293)] }}: 1
+Adjusted{7,std_Vec { x: [("a", 0), ("b", 1)] }}: 1
+Adjusted{8,std_Vec { x: [("a", 0), ("b", 1), ("c", 2), ("d", 3), ("e", 4), ("f", 5)] }}: 1
+Adjusted{9,std_Vec { x: [("x", 0), ("b", 10001), ("c", 10002), ("d", 10003), ("e", 10004), ("z", 10000)] }}: 1
+Adjusted{10,std_Vec { x: [("x", 0), ("b", 1), ("c", 2), ("d", 3), ("e", 4), ("z", 10000)] }}: 1
+Adjusted{11,std_Vec { x: [("x", 1), ("b", 6), ("c", 7), ("d", 8), ("e", 9), ("z", 5)] }}: 1
+Adjusted{12,std_Vec { x: [("x", 1), ("b", 6), ("c", 7), ("d", 8), ("e", 9), ("z", 5), ("p", 10), ("q", 0)] }}: 1
+Adjusted{13,std_Vec { x: [("x", 1), ("b", 6), ("c", 7), ("d", 8), ("e", 9), ("z", 5), ("p", 10), ("q", 0), ("r", 2)] }}: 1
+Adjusted{14,std_Vec { x: [("x", 4294967287), ("b", 4294967286), ("c", 4294967288), ("d", 4294967290), ("e", 4294967291), ("z", 4294967295), ("p", 4294967292), ("q", 4294967293), ("r", 4294967294)] }}: 1
+Adjusted{15,std_Vec { x: [("x", 16777207), ("b", 4294967286), ("c", 4294967287), ("d", 4294967288), ("e", 4294967289), ("z", 16777215), ("p", 4294967290), ("q", 4294967291), ("r", 4294967292)] }}: 1
+Adjusted{16,std_Vec { x: [("x", 11), ("b", 10), ("c", 12), ("d", 14), ("e", 15), ("z", 20), ("p", 16), ("q", 17), ("r", 18)] }}: 1
+Adjusted{17,std_Vec { x: [("x", 10), ("z", 12)] }}: 1
+Adjusted{18,std_Vec { x: [("x", 4294967293), ("z", 4294967295)] }}: 1
+Adjusted{19,std_Vec { x: [("x", 0), ("z", 2)] }}: 1
+Adjusted{20,std_Vec { x: [("x", 0), ("z", 2)] }}: 1
+Adjusted{21,std_Vec { x: [("x", 0), ("z", 2)] }}: 1
+
+NewAllocation:
+NewAllocation{1,std_Vec { x: [] }}: 1
+NewAllocation{2,std_Vec { x: [("a", 0)] }}: 1
+NewAllocation{3,std_Vec { x: [("a", 0)] }}: 1
+NewAllocation{4,std_Vec { x: [("a", 0), ("b", 1)] }}: 1
+NewAllocation{5,std_Vec { x: [("a", 1000), ("b", 1001)] }}: 1
+NewAllocation{5,std_Vec { x: [("a", 4294967294), ("b", 4294967295)] }}: 1
+NewAllocation{6,std_Vec { x: [("a", 4294967292), ("b", 4294967293)] }}: 1
+NewAllocation{7,std_Vec { x: [("a", 0), ("b", 1)] }}: 1
+NewAllocation{8,std_Vec { x: [("a", 0), ("b", 1), ("c", 2), ("d", 3), ("e", 4), ("f", 5)] }}: 1
+NewAllocation{9,std_Vec { x: [("x", 10001), ("b", 10002), ("c", 10003), ("d", 10004), ("e", 10005), ("z", 10006)] }}: 1
+NewAllocation{10,std_Vec { x: [("x", 1), ("b", 2), ("c", 3), ("d", 4), ("e", 5), ("z", 6)] }}: 1
+NewAllocation{11,std_Vec { x: [("x", 6), ("b", 7), ("c", 8), ("d", 9), ("e", 10), ("z", 0)] }}: 1
+NewAllocation{12,std_Vec { x: [("x", 6), ("b", 7), ("c", 8), ("d", 9), ("e", 10), ("z", 0), ("p", 2), ("q", 4)] }}: 1
+NewAllocation{13,std_Vec { x: [("x", 6), ("b", 7), ("c", 8), ("d", 9), ("e", 10), ("z", 0), ("p", 2), ("q", 4)] }}: 1
+NewAllocation{14,std_Vec { x: [("x", 4294967286), ("b", 4294967288), ("c", 4294967290), ("d", 4294967291), ("e", 4294967292), ("z", 4294967293), ("p", 4294967294)] }}: 1
+NewAllocation{15,std_Vec { x: [("x", 4294967286), ("b", 4294967287), ("c", 4294967288), ("d", 4294967289), ("e", 4294967290), ("z", 4294967291), ("p", 4294967292), ("q", 4294967293), ("r", 4294967294)] }}: 1
+NewAllocation{16,std_Vec { x: [("x", 10), ("b", 12), ("c", 14), ("d", 15), ("e", 16), ("z", 17), ("p", 18), ("q", 19)] }}: 1
+NewAllocation{17,std_Vec { x: [] }}: 1
+NewAllocation{18,std_Vec { x: [] }}: 1
+NewAllocation{19,std_Vec { x: [] }}: 1
+NewAllocation{20,std_Vec { x: [] }}: 1
+NewAllocation{21,std_Vec { x: [] }}: 1
+
+NewAllocationOpt:
+NewAllocationOpt{1,std_Vec { x: [] }}: 1
+NewAllocationOpt{2,std_Vec { x: [("a", std.Some{0})] }}: 1
+NewAllocationOpt{3,std_Vec { x: [("a", std.Some{0}), ("b", std.None{})] }}: 1
+NewAllocationOpt{4,std_Vec { x: [("a", std.Some{0}), ("b", std.Some{1})] }}: 1
+NewAllocationOpt{5,std_Vec { x: [("a", std.Some{1000}), ("b", std.Some{1001})] }}: 1
+NewAllocationOpt{5,std_Vec { x: [("a", std.Some{4294967294}), ("b", std.Some{4294967295})] }}: 1
+NewAllocationOpt{6,std_Vec { x: [("a", std.Some{4294967292}), ("b", std.Some{4294967293})] }}: 1
+NewAllocationOpt{7,std_Vec { x: [("a", std.Some{0}), ("b", std.Some{1})] }}: 1
+NewAllocationOpt{8,std_Vec { x: [("a", std.Some{0}), ("b", std.Some{1}), ("c", std.Some{2}), ("d", std.Some{3}), ("e", std.Some{4}), ("f", std.Some{5})] }}: 1
+NewAllocationOpt{9,std_Vec { x: [("x", std.Some{10001}), ("b", std.Some{10002}), ("c", std.Some{10003}), ("d", std.Some{10004}), ("e", std.Some{10005}), ("z", std.Some{10006})] }}: 1
+NewAllocationOpt{10,std_Vec { x: [("x", std.Some{1}), ("b", std.Some{2}), ("c", std.Some{3}), ("d", std.Some{4}), ("e", std.Some{5}), ("z", std.Some{6})] }}: 1
+NewAllocationOpt{11,std_Vec { x: [("x", std.Some{6}), ("b", std.Some{7}), ("c", std.Some{8}), ("d", std.Some{9}), ("e", std.Some{10}), ("z", std.Some{0})] }}: 1
+NewAllocationOpt{12,std_Vec { x: [("x", std.Some{6}), ("b", std.Some{7}), ("c", std.Some{8}), ("d", std.Some{9}), ("e", std.Some{10}), ("z", std.Some{0}), ("p", std.Some{2}), ("q", std.Some{4})] }}: 1
+NewAllocationOpt{13,std_Vec { x: [("x", std.Some{6}), ("b", std.Some{7}), ("c", std.Some{8}), ("d", std.Some{9}), ("e", std.Some{10}), ("z", std.Some{0}), ("p", std.Some{2}), ("q", std.Some{4}), ("r", std.None{})] }}: 1
+NewAllocationOpt{14,std_Vec { x: [("x", std.Some{4294967286}), ("b", std.Some{4294967288}), ("c", std.Some{4294967290}), ("d", std.Some{4294967291}), ("e", std.Some{4294967292}), ("z", std.Some{4294967293}), ("p", std.Some{4294967294}), ("q", std.None{}), ("r", std.None{})] }}: 1
+NewAllocationOpt{15,std_Vec { x: [("x", std.Some{4294967286}), ("b", std.Some{4294967287}), ("c", std.Some{4294967288}), ("d", std.Some{4294967289}), ("e", std.Some{4294967290}), ("z", std.Some{4294967291}), ("p", std.Some{4294967292}), ("q", std.Some{4294967293}), ("r", std.Some{4294967294})] }}: 1
+NewAllocationOpt{16,std_Vec { x: [("x", std.Some{10}), ("b", std.Some{12}), ("c", std.Some{14}), ("d", std.Some{15}), ("e", std.Some{16}), ("z", std.Some{17}), ("p", std.Some{18}), ("q", std.Some{19}), ("r", std.None{})] }}: 1
+NewAllocationOpt{17,std_Vec { x: [("x", std.None{}), ("b", std.None{}), ("c", std.None{}), ("d", std.None{}), ("e", std.None{}), ("z", std.None{}), ("p", std.None{}), ("q", std.None{}), ("r", std.None{})] }}: 1
+NewAllocationOpt{18,std_Vec { x: [("x", std.None{}), ("b", std.None{}), ("c", std.None{}), ("d", std.None{}), ("e", std.None{}), ("z", std.None{}), ("p", std.None{}), ("q", std.None{}), ("r", std.None{})] }}: 1
+NewAllocationOpt{19,std_Vec { x: [("x", std.None{}), ("b", std.None{}), ("c", std.None{}), ("d", std.None{}), ("e", std.None{}), ("z", std.None{}), ("p", std.None{}), ("q", std.None{}), ("r", std.None{})] }}: 1
+NewAllocationOpt{20,std_Vec { x: [("x", std.None{}), ("b", std.None{}), ("c", std.None{}), ("d", std.None{}), ("e", std.None{}), ("z", std.None{}), ("p", std.None{}), ("q", std.None{}), ("r", std.None{})] }}: 1
+NewAllocationOpt{21,std_Vec { x: [("x", std.None{}), ("b", std.None{}), ("c", std.None{}), ("d", std.None{}), ("e", std.None{}), ("z", std.None{}), ("p", std.None{}), ("q", std.None{}), ("r", std.None{})] }}: 1
+
 NewAllocation
 NewAllocation{1,std_Vec { x: [] }}
 NewAllocation{2,std_Vec { x: [("a", 0)] }}
@@ -498,11 +774,25 @@ Adjusted{18,std_Vec { x: [("x", 4294967293), ("z", 4294967295)] }}
 Adjusted{19,std_Vec { x: [("x", 0), ("z", 2)] }}
 Adjusted{20,std_Vec { x: [("x", 0), ("z", 2)] }}
 Adjusted{21,std_Vec { x: [("x", 0), ("z", 2)] }}
+YX:
+YX{10,1}: 1
+YX{20,2}: 1
+YX{30,3}: 1
+YX{40,4}: 1
+
 YX
 YX{10,1}
 YX{20,2}
 YX{30,3}
 YX{40,4}
+SCCLabel:
+(2, 2): 1
+(3, 2): 1
+(4, 2): 1
+(5, 5): 1
+(6, 5): 1
+(7, 5): 1
+
 SCCLabel
 (2, 2)
 (3, 2)
@@ -510,6 +800,20 @@ SCCLabel
 (5, 5)
 (6, 5)
 (7, 5)
+ConcatString:
+ConcatString{"Foo bar"}: 1
+ConcatString{"Foo world"}: 1
+ConcatString{"Hello, bar"}: 1
+ConcatString{"Hello, world"}: 1
+
+StringOrd:
+StringOrd{"Foo ",3}: 1
+StringOrd{"Foo bar",6}: 1
+StringOrd{"Foo world",7}: 1
+StringOrd{"Hello, ",2}: 1
+StringOrd{"Hello, bar",4}: 1
+StringOrd{"Hello, world",5}: 1
+
 ConcatString
 ConcatString{"Foo bar"}
 ConcatString{"Foo world"}
@@ -522,6 +826,16 @@ StringOrd{"Foo world",7}
 StringOrd{"Hello, ",2}
 StringOrd{"Hello, bar",4}
 StringOrd{"Hello, world",5}
+CMethod:
+CMethod{"bar","foo"}: 1
+CMethod{"buzz","foo"}: 1
+CMethod{"hello","world"}: 1
+
+DMethod:
+DMethod{"bar","foo"}: 1
+DMethod{"buzz","foo"}: 1
+DMethod{"hello","world"}: 1
+
 CMethod
 CMethod{"bar","foo"}
 CMethod{"buzz","foo"}
@@ -530,12 +844,29 @@ DMethod
 DMethod{"bar","foo"}
 DMethod{"buzz","foo"}
 DMethod{"hello","world"}
+Power3:
+Power3{0}: 1
+Power3{1}: 1
+Power3{8}: 1
+Power3{27}: 1
+Power3{64}: 1
+
 Power3
 Power3{0}
 Power3{1}
 Power3{8}
 Power3{27}
 Power3{64}
+RegexMatch:
+RegexMatch{"(?i)a+(?-i)b+","AaAaAbbBBBb",true}: 1
+RegexMatch{"[0-9]{3}-[0-9]{3}-[0-9]{4}","111-222-333",false}: 1
+RegexMatch{"[0-9]{3}-[0-9]{3}-[0-9]{4}","111-222-3333",true}: 1
+RegexMatch{"[0-9]{3}-[0-9]{3}-[0-9]{4}","phone: 111-222-3333",true}: 1
+RegexMatch{"^[0-9]{4}-[0-9]{2}-[0-9]{2}$","2014-01-01",true}: 1
+RegexMatch{"^[0-9]{4}-[0-9]{2}-[0-9]{2}$","2014-0101",false}: 1
+RegexMatch{"a+b+","AaAaAbbBBBb",false}: 1
+RegexMatch{"a+b+","aaaaabbbbbb",true}: 1
+
 RegexMatch
 RegexMatch{"(?i)a+(?-i)b+","AaAaAbbBBBb",true}
 RegexMatch{"[0-9]{3}-[0-9]{3}-[0-9]{4}","111-222-333",false}


### PR DESCRIPTION
This PR introduces a modular framework for handling update notifications
from differential.

At the low level differential supports a callback API that gets invoked
every time a record is added or deleted in an output relation.  
DDlog can perform one or more of the following actions inside the callback:
(1) invoke an extern "C" callback, (2) apply update to a copy of output relations
cached by DDlog, (3) (as of this PR) accumulate changes across one or
multiple transactions, (4) (as of this PR) forwarding the update to a worker
thread that can perform any combination of 1,2,3, and, in the future, (5) forwarding
update to a pool of worker threads.

To make arbitrary combinations of the above, as well as other possible future features,
this PR introduces a modular framework that allows chaining the above actions in arbitrary
ways. It also implements (3) and (4) above. (4) is now in use by default; (3) is available
through a new API method: `transaction_commit_dump_changes()`